### PR TITLE
JENKINS-16786: make coverage column show N/A as white, not black

### DIFF
--- a/src/main/java/hudson/plugins/jacococoveragecolumn/JaCoCoColumn.java
+++ b/src/main/java/hudson/plugins/jacococoveragecolumn/JaCoCoColumn.java
@@ -6,7 +6,6 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.plugins.jacoco.JacocoBuildAction;
 import hudson.plugins.jacoco.model.Coverage;
-import hudson.plugins.jacoco.report.CoverageReport;
 import hudson.views.ListViewColumn;
 
 import java.awt.Color;
@@ -43,17 +42,37 @@ public class JaCoCoColumn extends ListViewColumn {
 		return stringBuilder.toString();
 	}
 
-	public String getLineColor(final BigDecimal amount) {
+	public String getLineColor(final Job<?, ?> job, final BigDecimal amount) {
 		if (amount == null) {
 			return null;
 		}
+
+		if(job != null) {
+			final Run<?, ?> lastSuccessfulBuild = job.getLastSuccessfulBuild();
+			if (lastSuccessfulBuild == null) {
+				return CoverageRange.NA.getLineHexString();
+			} else if (lastSuccessfulBuild.getAction(JacocoBuildAction.class) == null){
+				return CoverageRange.NA.getLineHexString();
+			}
+		}
+
 		return CoverageRange.valueOf(amount.doubleValue()).getLineHexString();
 	}
 
-	public String getFillColor(final BigDecimal amount) {
+	public String getFillColor(final Job<?, ?> job, final BigDecimal amount) {
 		if (amount == null) {
 			return null;
 		}
+
+		if(job != null) {
+			final Run<?, ?> lastSuccessfulBuild = job.getLastSuccessfulBuild();
+			if (lastSuccessfulBuild == null) {
+				return CoverageRange.NA.getFillHexString();
+			} else if (lastSuccessfulBuild.getAction(JacocoBuildAction.class) == null){
+				return CoverageRange.NA.getFillHexString();
+			}
+		}
+
 		final Color c = CoverageRange.fillColorOf(amount.doubleValue());
 		return CoverageRange.colorAsHexString(c);
 	}

--- a/src/main/resources/hudson/plugins/jacococoveragecolumn/JaCoCoColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/jacococoveragecolumn/JaCoCoColumn/column.jelly
@@ -3,8 +3,8 @@
     <j:when test="${it != null}">
       <j:set var="coverageAmount" value="${it.getLineCoverage(job)}" />
       <j:set var="coveragePercent" value="${it.getPercent(job)}" />
-      <j:set var="color" value="${it.getLineColor(coverageAmount)}" />
-      <j:set var="backgroundColor" value="${it.getFillColor(coverageAmount)}" />
+      <j:set var="color" value="${it.getLineColor(job, coverageAmount)}" />
+      <j:set var="backgroundColor" value="${it.getFillColor(job, coverageAmount)}" />
     </j:when>
     <j:otherwise>
       <j:set var="coverageAmount" value="${null}" />

--- a/src/test/java/hudson/plugins/jacococoveragecolumn/CoverageRangeTest.java
+++ b/src/test/java/hudson/plugins/jacococoveragecolumn/CoverageRangeTest.java
@@ -1,6 +1,6 @@
 package hudson.plugins.jacococoveragecolumn;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.awt.Color;
 
@@ -26,5 +26,38 @@ public class CoverageRangeTest {
 	public void testFillColorOfHandlesNull() throws Exception {
 		final Color color = CoverageRange.fillColorOf(null);
 		assertEquals(CoverageRange.ABYSSMAL.getFillColor(), color);
+	}
+	
+	@Test
+	public void test() {
+		expect(CoverageRange.ABYSSMAL, -20.0);
+		expect(CoverageRange.ABYSSMAL, 0.0);
+		expect(CoverageRange.ABYSSMAL, 10.3);
+		expect(CoverageRange.TRAGIC, 25.0);
+		expect(CoverageRange.TRAGIC, 32.0);
+		expect(CoverageRange.POOR, 50.0);
+		expect(CoverageRange.POOR, 68.2);
+		expect(CoverageRange.FAIR, 75.0);
+		expect(CoverageRange.FAIR, 83.0);
+		expect(CoverageRange.SUFFICIENT, 85.0);
+		expect(CoverageRange.SUFFICIENT, 91.0);
+		expect(CoverageRange.GOOD, 92.0);
+		expect(CoverageRange.GOOD, 96.999);
+		expect(CoverageRange.EXCELLENT, 97.0);
+		expect(CoverageRange.EXCELLENT, 97.1);
+		expect(CoverageRange.PERFECT, 100.0);
+		expect(CoverageRange.PERFECT, 230.0);
+	}
+	
+	private void expect(CoverageRange result, double value) {
+		assertEquals(result, CoverageRange.valueOf(value));
+		assertNotNull(CoverageRange.fillColorOf(value));
+		assertNotNull(result.getLineColor());
+		assertNotNull(result.getFillHexString());
+		assertNotNull(result.getLineHexString());
+		assertNotNull(CoverageRange.colorAsHexString(result.getLineColor()));
+		assertTrue("Had " + value + " and floor " + result.getFloor(),
+				value < 0 || 	// special handling for negative values, should not be passed in anyway
+				value >= result.getFloor());
 	}
 }


### PR DESCRIPTION
Color for NA was prepared, but not really used yet, fixed now. 

Also enhance unit tests for the coverage column classes.
