### PR TITLE
Add help-entries for some of the configuration of the build action

### DIFF
--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
@@ -34,13 +34,13 @@
       		<col width="39%"/>
       <tr>
         <td>Inclusions (e.g.: **/*.class)</td>
-        <td>Exclusions (e.g.: **/*Test*)</td>
+        <td>Exclusions (e.g.: **/*Test*.class)</td>
       </tr>
       
       <tr>
         
         <td>
-          <f:textbox field="inclusionPattern"  default=""/>
+          <f:textbox field="inclusionPattern" default=""/>
         </td>
         
         <td>
@@ -122,7 +122,7 @@
 	        </tbody>
 	    </table>
   </f:entry>
-  <f:entry>
-   <f:checkbox field="changeBuildStatus" checked="${instance.selected}" title="Change build status according the thresholds"/>
+  <f:entry field="changeBuildStatus">
+   <f:checkbox checked="${instance.selected}" title="Change build status according the thresholds"/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/help-changeBuildStatus.html
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/help-changeBuildStatus.html
@@ -1,0 +1,3 @@
+<div>
+	Check this to set the build status to unstable if coverage thresholds are violated. 
+</div>

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/help.html
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/help.html
@@ -1,0 +1,7 @@
+<div>
+	Allows to configure various aspects of the JaCoCo code coverage report. The pathes define where the various types of files
+	can be found in the workspace, inclusions and exclusions allow to exclude certain class files.
+	
+	And the coverage thresholds allow to configure how much coverage is necessary to make the build green (if changing the build
+	status is enabled).
+</div>


### PR DESCRIPTION
Also make it more obvious in the page-description that .class-files are handled in the exclusions, I stumbled across this and had to debug into it to actually find out what was wrong...

The change for the f:entry field="buildStatus... is necessary to enable specific help on the single field.
