### PR TITLE
Changed rendering of percentgraph

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/model/CoverageObject.java
+++ b/src/main/java/hudson/plugins/jacoco/model/CoverageObject.java
@@ -315,12 +315,12 @@ public abstract class CoverageObject<SELF extends CoverageObject<SELF>> {
 		}
 		buf.append("<table class='percentgraph' cellpadding='0px' cellspacing='0px'>")
 		.append("<tr>" +
-				"<td class='percentgraph'>").append("<span class='text'>").append("<b>M:</b> "+numerator).append(" ").append("<b>C:</b> "+ denominator).append("</span></td></tr>")
+				"<td class='percentgraph' colspan='2'>").append("<span class='text'>").append("<b>M:</b> "+numerator).append(" ").append("<b>C:</b> "+ denominator).append("</span></td></tr>")
 		.append("<tr>")
 		    .append("<td width='40px' class='data'>").append(ratio.getPercentage()).append("%</td>")	
 		    .append("<td>")
-		    .append("<div class='percentgraph' style='width: ").append(((float)ratio.getCovered()/(float)maximumCovered)*100).append("px;'>")
-		    .append("<div class='redbar' style='width: ").append(ratio.getMissed()> ratio.getCovered() ? ((float)ratio.getMissed()/(float)maximumMissed)*100: ((float)ratio.getMissed()/(float)maximumCovered)*100).append("px;'>")
+		    .append("<div class='percentgraph' style='width: 100px;'>")
+		    .append("<div class='redbar' style='width: ").append((float)ratio.getMissed()/(ratio.getCovered() + ratio.getMissed()) *100.0).append("px;'>")
 		    .append("</td></tr>")
 		    .append("</table>");
 	}

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -138,8 +138,8 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 		buf.append("<table class='percentgraph' cellpadding='0px' cellspacing='0px'><tr class='percentgraph'>")
 		.append("<td width='40px' class='data'>").append(ratio.getPercentage()).append("%</td>")
 		.append("<td class='percentgraph'>")
-		.append("<div class='percentgraph' style='width: ").append(100).append("px;'>")
-		.append("<div class='redbar' style='width: ").append(ratio.getMissed() > ratio.getCovered() ? 100 :  ((float)ratio.getMissed()/(float)ratio.getCovered())*100).append("px;'>")
+		.append("<div class='percentgraph' style='width: 100px;'>")
+		.append("<div class='redbar' style='width: ").append((float)ratio.getMissed()/(ratio.getCovered() + ratio.getMissed()) *100.0).append("px;'>")
 		.append("</div></div></td></tr>" +
 				"<tr>").append("<span class='text'>").append("<b>M:</b> "+numerator).append(" ").append("<b>C:</b> "+ denominator).append("</span></tr>").append("</table>");
 	}

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -44,6 +44,7 @@ div.percentgraph div.redbar {
   height: 1.3em;
   margin: 0px;
   padding: 0px;
+  float: right;
 }
 
 div.percentgraph div.na {


### PR DESCRIPTION
The bars indicating code coverage were a tad confusing so I changed them:
- All bars are always 100px wide.
- Starts with green, then red.
- Percentage of the red bar is calculated as 

```
missed / (covered + missed)
```
