### PR TITLE
[FIXED JENKINS-20440]

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -39,7 +39,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 	
 	@Deprecated public transient AbstractBuild<?,?> build;
 	
-	public final PrintStream logger;
+	public final transient PrintStream logger;
 	@Deprecated private transient ArrayList reports;
 	private transient WeakReference<CoverageReport> report;
 	private final String[] inclusions;


### PR DESCRIPTION
Change to make JacocoBuildAction.logger transient. This will prevent the
serialization of the PrintStream buffer.

See https://issues.jenkins-ci.org/secure/attachment/24644/build.xml for an example.
