### PR TITLE
JENKINS-24450 JacocoPublisher serializes concurrent builds waiting for checkpoint

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -250,7 +250,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			if(b==null) {
 				return null;
 			}
-			if(b.getResult()== Result.FAILURE || b.getResult() == Result.ABORTED) {
+			if (b.isBuilding() || b.getResult() == Result.FAILURE || b.getResult() == Result.ABORTED) {
 				continue;
 			}
 			JacocoBuildAction r = b.getAction(JacocoBuildAction.class);

--- a/src/main/java/hudson/plugins/jacoco/JacocoProjectAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoProjectAction.java
@@ -39,7 +39,7 @@ public final class JacocoProjectAction implements Action {
      */
     public JacocoBuildAction getLastResult() {
         for (AbstractBuild<?, ?> b = project.getLastBuild(); b != null; b = b.getPreviousBuild()) {
-            if (b.getResult() == Result.FAILURE || b.getResult() == Result.ABORTED)
+            if (b.isBuilding() || b.getResult() == Result.FAILURE || b.getResult() == Result.ABORTED)
                 continue;
             JacocoBuildAction r = b.getAction(JacocoBuildAction.class);
             if (r != null)

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -404,7 +404,7 @@ public class JacocoPublisher extends Recorder {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/jacoco/portlet/JacocoLoadData.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/JacocoLoadData.java
@@ -84,7 +84,7 @@ public final class JacocoLoadData {
     // date range (last build date minus number of days)
     for (Job job : jobs) {
 
-      Run run = job.getLastBuild();
+      Run run = job.getLastCompletedBuild();
 
       if (null != run) {
         LocalDate runDate = new LocalDate(run.getTimestamp());
@@ -94,6 +94,9 @@ public final class JacocoLoadData {
           summarize(summaries, run, runDate, job);
 
           run = run.getPreviousBuild();
+          while (run != null && run.isBuilding()) {
+            run = run.getPreviousBuild();
+          }
 
           if (null == run) {
             break;

--- a/src/main/java/hudson/plugins/jacoco/portlet/utils/Utils.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/utils/Utils.java
@@ -96,7 +96,7 @@ public final class Utils {
   public static LocalDate getLastDate(List<Job> jobs) {
     LocalDate lastDate = null;
     for (Job<?,?> job : jobs) {
-      Run<?,?> lastRun = job.getLastBuild();
+      Run<?,?> lastRun = job.getLastCompletedBuild();
       if (lastRun != null) {
         LocalDate date = new LocalDate(lastRun.getTimestamp());
         if (lastDate == null) {


### PR DESCRIPTION
See the bug for a description of the problem and the cause.

The solution is to switch from BuildStepMonitor.BUILD to BuildStepMonitor.NONE. This necessitates auditing the code for the assumption that all previous builds have completed and making the necessary adjustments.

To accomplish the above, we grepped for Job#getLastBuild, Job#getFirstBuild, Run#getPreviousBuild(), Run#getPreviousBuildInProgress, and Run#getPreviousBuiltBuild throughout the codebase. We then examined all the methods that use this functionality and adapted them to work under the new assumption that previous builds may be still running.

In particular, we made the utility methods in JacocoBuildAction and JacocoProjectAction skip over builds that are in progress while building the data model for the coverage graph. We also updated the portlet classes JacocoLoadData and Utils to start at the last completed build (instead of the last build, which could be currently running) and to skip over currently running builds when iterating backwards in time.
