### PR TITLE
JENKINS-24029: Fixed incorrect indentation in sourcefiles. 

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/report/SourceAnnotator.java
+++ b/src/main/java/hudson/plugins/jacoco/report/SourceAnnotator.java
@@ -38,7 +38,7 @@ public class SourceAnnotator {
             br = new BufferedReader(new FileReader(src));
             String line;
             while ((line = br.readLine()) != null) {
-                aList.add(line.replaceAll("\\t", "&nbsp&nbsp&nbsp&nbsp").replaceAll("<", "&lt").replaceAll(">", "&gt"));
+                aList.add(line.replaceAll("\\t", "&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp").replaceAll("<", "&lt").replaceAll(">", "&gt"));
             }
         } catch (FileNotFoundException e) {
             e.printStackTrace();


### PR DESCRIPTION
Indentation is done according to java code convention (http://www.oracle.com/technetwork/java/codeconventions-150003.pdf, Section 4): "Tabs must be set exactly every 8 spaces (not 4).