### PR TITLE
Always create report directories

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -337,6 +337,7 @@ public class JacocoPublisher extends Recorder {
         logger.println("[JaCoCo plugin] " + execPattern + ";" + classPattern +  ";" + sourcePattern + ";" + " locations are configured");
 
         JacocoReportDir dir = new JacocoReportDir(build);
+        dir.createDirs();
 
         List<FilePath> matchedExecFiles = Arrays.asList(build.getWorkspace().list(resolveFilePaths(build, listener, execPattern)));
         logger.println("[JaCoCo plugin] Number of found exec files for pattern " + execPattern + ": " + matchedExecFiles.size());


### PR DESCRIPTION
Create report directories (classes, sources, execFiles) even if
the patterns does not select any files or directories.

Without it, misconfiguration results an exception:
java.lang.IllegalStateException: basedir /data/jenkins/jobs/myjob/builds/272/jacoco/classes does not exist
    at org.codehaus.plexus.util.DirectoryScanner.scan(DirectoryScanner.java:550)
    at org.codehaus.plexus.util.FileUtils.getFileAndDirectoryNames(FileUtils.java:1717)
    at org.codehaus.plexus.util.FileUtils.getFileNames(FileUtils.java:1645)
    at org.codehaus.plexus.util.FileUtils.getFileNames(FileUtils.java:1627)
    at org.codehaus.plexus.util.FileUtils.getFiles(FileUtils.java:1601)
    at org.codehaus.plexus.util.FileUtils.getFiles(FileUtils.java:1584)
    at hudson.plugins.jacoco.ExecutionFileLoader.analyzeStructure(ExecutionFileLoader.java:124)
    at hudson.plugins.jacoco.ExecutionFileLoader.loadBundleCoverage(ExecutionFileLoader.java:133)
    at hudson.plugins.jacoco.JacocoReportDir.parse(JacocoReportDir.java:102)
    at hudson.plugins.jacoco.JacocoBuildAction.loadRatios(JacocoBuildAction.java:291)
    at hudson.plugins.jacoco.JacocoBuildAction.load(JacocoBuildAction.java:273)
    at hudson.plugins.jacoco.JacocoPublisher.perform(JacocoPublisher.java:371)
    at hudson.plugins.templateproject.ProxyPublisher.perform(ProxyPublisher.java:71)
    at hudson.tasks.BuildStepMonitor$2.perform(BuildStepMonitor.java:32)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:761)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:721)
    at hudson.model.Build$BuildExecution.post2(Build.java:183)
    at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:670)
    at hudson.model.Run.execute(Run.java:1766)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:374)
