### PR TITLE
Update jacoco version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ THE SOFTWARE.
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <jacoco.version>0.7.4.201502262128</jacoco.version>
+      <jacoco.version>0.7.5.201505241946</jacoco.version>
    </properties>
 
    <repositories>


### PR DESCRIPTION
jacoco [0.7.5 has been released](http://www.eclemma.org/jacoco/)