### PR TITLE
JENKINS-31751: Fix HTML rendering by correctly escaping it in jelly files.

### DIFF
--- a/src/main/resources/hudson/plugins/jacoco/tags/breakdownMethodsTable.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/tags/breakdownMethodsTable.jelly
@@ -7,7 +7,7 @@
         <td class="${h.ifThenElse(c.failed,' red','')}" style="white-space: normal;">
           <a href="${h.ifThenElse(nolink!=null,null,c.name+'/')}"><st:out value="${c.name}"/></a>
         </td>	      
-        ${c.printFourCoverageColumns()}
+        <j:out value="${c.printFourCoverageColumns()}"/>
       </tr>
     </j:forEach>
   </table>

--- a/src/main/resources/hudson/plugins/jacoco/tags/breakdownTable.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/tags/breakdownTable.jelly
@@ -7,7 +7,7 @@
         <td class="nowrap ${h.ifThenElse(c.failed,' red','')}" >
           <a href="${h.ifThenElse(nolink!=null,null,c.name+'/')}"><st:out value="${c.name}"/></a>
         </td>	      
-        ${c.printFourCoverageColumns()}
+        <j:out value="${c.printFourCoverageColumns()}"/>
       </tr>
     </j:forEach>
   </table>

--- a/src/main/resources/hudson/plugins/jacoco/tags/summaryMethod.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/tags/summaryMethod.jelly
@@ -4,7 +4,7 @@
     <e:captionLine />
     <tr>
       <td>${title}</td>
-      ${it.printFourCoverageColumns()}
+      <j:out value="${it.printFourCoverageColumns()}"/>
     </tr>
   </table>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/jacoco/tags/summaryTable.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/tags/summaryTable.jelly
@@ -4,7 +4,7 @@
     <e:captionLine />
     <tr>
       <td>${title}</td>
-      ${it.printFourCoverageColumns()}
+      <j:out value="${it.printFourCoverageColumns()}"/>
     </tr>
   </table>
 </j:jelly>


### PR DESCRIPTION
According to [1], starting with Jenkins version 1.339, setting `escape-by-default` to true is encouraged. However, any generated HTML must then be escaped using `<j:out />`, otherwise it will be displayed without being rendered.

[1] https://wiki.jenkins-ci.org/display/JENKINS/Jelly+and+XSS+prevention