### PR TITLE
Handle Jenkins publisher case when classes directory is empty

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -126,7 +126,7 @@ public class ExecutionFileLoader implements Serializable {
 				for (final File file : filesToAnalyze) {
 					analyzer.analyzeAll(file);
 				}
-			} catch (final IOException e) {
+			} catch (final Exception e) {
 				System.out.println("While reading class directory: " + classDirectory);
 				e.printStackTrace();
 			}

--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -120,12 +120,16 @@ public class ExecutionFileLoader implements Serializable {
 			}
 
 			final FileFilter fileFilter = new FileFilter(Arrays.asList(includes), Arrays.asList(excludes));
-			@SuppressWarnings("unchecked")
-			final List<File> filesToAnalyze = FileUtils.getFiles(classDirectory, fileFilter.getIncludes(), fileFilter.getExcludes());
-			for (final File file : filesToAnalyze) {
-				analyzer.analyzeAll(file);
-	        }
-	        
+			try {
+				@SuppressWarnings("unchecked")
+				final List<File> filesToAnalyze = FileUtils.getFiles(classDirectory, fileFilter.getIncludes(), fileFilter.getExcludes());
+				for (final File file : filesToAnalyze) {
+					analyzer.analyzeAll(file);
+				}
+			} catch (final IOException e) {
+				System.out.println("While reading class directory: " + classDirectory);
+				e.printStackTrace();
+			}
 			return coverageBuilder.getBundle(name);
 		}
 	    public IBundleCoverage loadBundleCoverage() throws IOException {

--- a/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
+++ b/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
@@ -113,4 +113,27 @@ public class ExecutionFileLoaderTest {
 				coverage.getClassCounter().getMissedCount() > 0 ||
 				coverage.getClassCounter().getCoveredCount() > 0);
 	}
+	
+	@Test
+	public void testLoadBundleWithoutClasses() throws IOException {
+		// Special Jenkins publisher case to handle empty classes dir
+		ExecutionFileLoader loader = new ExecutionFileLoader();
+		
+		assertTrue("This test requires that a jacoco.exec file exists in the target-directory", 
+				new File("target/jacoco.exec").exists());
+		File noClasses = new File("target/noclasses");
+		noClasses.mkdir();
+		assertTrue("This test requires that noclasses dir exists", 
+				noClasses.exists() && noClasses.isDirectory());
+		loader.setClassDir(new FilePath(noClasses));
+		loader.setExcludes(new String[] {"excludme.test"});
+		loader.addExecFile(new FilePath(new File("target/jacoco.exec")));
+		
+		// handles empty classes dir gracefully
+		IBundleCoverage coverage = loader.loadBundleCoverage();
+		assertNotNull(coverage);
+		assertTrue("Expect to have no lines found, but had: " + coverage.getClassCounter(), 
+				coverage.getClassCounter().getMissedCount() == 0 ||
+				coverage.getClassCounter().getCoveredCount() == 0);
+	}
 }


### PR DESCRIPTION
This commit adds a try/catch when trying to load the classes content and its empty.  Mirrors the approach taken when trying to load exec files which don't exist.
Also, adds a testcase to verify that an empty classes directory is handled, which can happen to the publisher plugin if the build is not producing class files but simply building a war or uber jar from other inputs.