### PR TITLE
Use full precision when comparing coverage to thresholds

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -118,10 +118,11 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			return null;
 		}
 		thresholds.ensureValid();
-		int score = 100, percent;
+		int score = 100;
+		float percent;
 		ArrayList<Localizable> reports = new ArrayList<Localizable>(5);
 		if (clazz != null && thresholds.getMaxClass() > 0) {
-			percent = clazz.getPercentage();
+			percent = clazz.getPercentageFloat();
 			if (percent < thresholds.getMaxClass()) {
 				reports.add(Messages._BuildAction_Classes(clazz, percent));
 			}
@@ -129,7 +130,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 					percent, thresholds.getMaxClass());
 		}
 		if (method != null && thresholds.getMaxMethod() > 0) {
-			percent = method.getPercentage();
+			percent = method.getPercentageFloat();
 			if (percent < thresholds.getMaxMethod()) {
 				reports.add(Messages._BuildAction_Methods(method, percent));
 			}
@@ -137,7 +138,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 					percent, thresholds.getMaxMethod());
 		}
 		if (line != null && thresholds.getMaxLine() > 0) {
-			percent = line.getPercentage();
+			percent = line.getPercentageFloat();
 			if (percent < thresholds.getMaxLine()) {
 				reports.add(Messages._BuildAction_Lines(line, percent));
 			}
@@ -145,7 +146,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 					percent, thresholds.getMaxLine());
 		}
 		if (branch != null && thresholds.getMaxBranch() > 0) {
-			percent = branch.getPercentage();
+			percent = branch.getPercentageFloat();
 			if (percent < thresholds.getMaxBranch()) {
 				reports.add(Messages._BuildAction_Branches(branch, percent));
 			}
@@ -153,7 +154,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 					percent, thresholds.getMaxBranch());
 		}
 		if (instruction != null && thresholds.getMaxInstruction() > 0) {
-			percent = instruction.getPercentage();
+			percent = instruction.getPercentageFloat();
 			if (percent < thresholds.getMaxInstruction()) {
 				reports.add(Messages._BuildAction_Instructions(instruction, percent));
 			}
@@ -181,7 +182,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 		return thresholds;
 	}
 
-	private static int updateHealthScore(int score, int min, int value, int max) {
+	private static int updateHealthScore(int score, int min, float value, int max) {
 		if (value >= max) {
 			return score;
 		}
@@ -189,7 +190,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			return 0;
 		}
 		assert max != min;
-		final int scaled = (int) (100.0 * ((float) value - min) / (max - min));
+		final int scaled = (int) (100.0 * (value - min) / (max - min));
 		if (scaled < score) {
 			return scaled;
 		}

--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -262,12 +262,12 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			lineCoverage.setType(CoverageElement.Type.LINE);
 			methodCoverage.setType(CoverageElement.Type.METHOD);
 			
-			ratios.put(instructionCoverage,JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == thresholds.getResultByTypeAndRatio(instructionCoverage));
-			ratios.put(branchCoverage,JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == thresholds.getResultByTypeAndRatio(branchCoverage));
-			ratios.put(complexityScore,JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == thresholds.getResultByTypeAndRatio(complexityScore));
-			ratios.put(lineCoverage,JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == thresholds.getResultByTypeAndRatio(lineCoverage));
-			ratios.put(methodCoverage,JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == thresholds.getResultByTypeAndRatio(methodCoverage));
-			ratios.put(classCoverage,JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == thresholds.getResultByTypeAndRatio(classCoverage));
+			ratios.put(instructionCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(instructionCoverage));
+			ratios.put(branchCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(branchCoverage));
+			ratios.put(complexityScore,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(complexityScore));
+			ratios.put(lineCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(lineCoverage));
+			ratios.put(methodCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(methodCoverage));
+			ratios.put(classCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(classCoverage));
 		}
 		return ratios;
 	}

--- a/src/main/java/hudson/plugins/jacoco/JacocoHealthReportThresholds.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoHealthReportThresholds.java
@@ -170,40 +170,40 @@ public class JacocoHealthReportThresholds implements Serializable {
 		    Type covType = ratio.getType();
 		    
 			if (covType == Type.INSTRUCTION) {
-				if (ratio.getPercentage() < minInstruction) {
+				if (ratio.getPercentageFloat() < minInstruction) {
 					result = RESULT.BELLOWMINIMUM;
-				} else if (ratio.getPercentage() < maxInstruction) {
+				} else if (ratio.getPercentageFloat() < maxInstruction) {
 					result = RESULT.BETWEENMINMAX;
 				}
 				
 			} else if (covType == Type.BRANCH) {
-				if (ratio.getPercentage() < minBranch) {
+				if (ratio.getPercentageFloat() < minBranch) {
 					result = RESULT.BELLOWMINIMUM;
-				} else if (ratio.getPercentage() < maxBranch) {
+				} else if (ratio.getPercentageFloat() < maxBranch) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.LINE) {
-				if (ratio.getPercentage() < minLine) {
+				if (ratio.getPercentageFloat() < minLine) {
 					result = RESULT.BELLOWMINIMUM;
-				} else if (ratio.getPercentage() < maxLine) {
+				} else if (ratio.getPercentageFloat() < maxLine) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.COMPLEXITY) {
-				if (ratio.getPercentage() < minComplexity) {
+				if (ratio.getPercentageFloat() < minComplexity) {
 					result = RESULT.BELLOWMINIMUM;
-				} else if (ratio.getPercentage() < maxComplexity) {
+				} else if (ratio.getPercentageFloat() < maxComplexity) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.METHOD) {
-				if (ratio.getPercentage() < minMethod) {
+				if (ratio.getPercentageFloat() < minMethod) {
 					result = RESULT.BELLOWMINIMUM;
-				} else if (ratio.getPercentage() < maxMethod) {
+				} else if (ratio.getPercentageFloat() < maxMethod) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.CLASS) {
-				if (ratio.getPercentage() < minClass) {
+				if (ratio.getPercentageFloat() < minClass) {
 					result = RESULT.BELLOWMINIMUM;
-				} else if (ratio.getPercentage() < maxClass) {
+				} else if (ratio.getPercentageFloat() < maxClass) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			}

--- a/src/main/java/hudson/plugins/jacoco/JacocoHealthReportThresholds.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoHealthReportThresholds.java
@@ -52,7 +52,7 @@ public class JacocoHealthReportThresholds implements Serializable {
         return value;
     }
 
-    public enum RESULT {BELLOWMINIMUM, BETWEENMINMAX, ABOVEMAXIMUM}
+    public enum RESULT {BELOWMINIMUM, BETWEENMINMAX, ABOVEMAXIMUM}
     
     public void ensureValid() {
         maxClass = applyRange(0, maxClass, 100);
@@ -171,38 +171,38 @@ public class JacocoHealthReportThresholds implements Serializable {
 		    
 			if (covType == Type.INSTRUCTION) {
 				if (ratio.getPercentageFloat() < minInstruction) {
-					result = RESULT.BELLOWMINIMUM;
+					result = RESULT.BELOWMINIMUM;
 				} else if (ratio.getPercentageFloat() < maxInstruction) {
 					result = RESULT.BETWEENMINMAX;
 				}
 				
 			} else if (covType == Type.BRANCH) {
 				if (ratio.getPercentageFloat() < minBranch) {
-					result = RESULT.BELLOWMINIMUM;
+					result = RESULT.BELOWMINIMUM;
 				} else if (ratio.getPercentageFloat() < maxBranch) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.LINE) {
 				if (ratio.getPercentageFloat() < minLine) {
-					result = RESULT.BELLOWMINIMUM;
+					result = RESULT.BELOWMINIMUM;
 				} else if (ratio.getPercentageFloat() < maxLine) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.COMPLEXITY) {
 				if (ratio.getPercentageFloat() < minComplexity) {
-					result = RESULT.BELLOWMINIMUM;
+					result = RESULT.BELOWMINIMUM;
 				} else if (ratio.getPercentageFloat() < maxComplexity) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.METHOD) {
 				if (ratio.getPercentageFloat() < minMethod) {
-					result = RESULT.BELLOWMINIMUM;
+					result = RESULT.BELOWMINIMUM;
 				} else if (ratio.getPercentageFloat() < maxMethod) {
 					result = RESULT.BETWEENMINMAX;
 				} 
 			} else if (covType == Type.CLASS) {
 				if (ratio.getPercentageFloat() < minClass) {
-					result = RESULT.BELLOWMINIMUM;
+					result = RESULT.BELOWMINIMUM;
 				} else if (ratio.getPercentageFloat() < maxClass) {
 					result = RESULT.BETWEENMINMAX;
 				} 

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -395,10 +395,10 @@ public class JacocoPublisher extends Recorder {
     }
 
 	public Result checkResult(JacocoBuildAction action) {
-		if ((action.getBranchCoverage().getPercentage() < action.getThresholds().getMinBranch()) || (action.getInstructionCoverage().getPercentage() < action.getThresholds().getMinInstruction())  || (action.getClassCoverage().getPercentage() < action.getThresholds().getMinClass())  || (action.getLineCoverage().getPercentage() < action.getThresholds().getMinLine())  || (action.getComplexityScore().getPercentage() < action.getThresholds().getMinComplexity())  || (action.getMethodCoverage().getPercentage() < action.getThresholds().getMinMethod())) {
+		if ((action.getBranchCoverage().getPercentageFloat() < action.getThresholds().getMinBranch()) || (action.getInstructionCoverage().getPercentageFloat() < action.getThresholds().getMinInstruction())  || (action.getClassCoverage().getPercentageFloat() < action.getThresholds().getMinClass())  || (action.getLineCoverage().getPercentageFloat() < action.getThresholds().getMinLine())  || (action.getComplexityScore().getPercentageFloat() < action.getThresholds().getMinComplexity())  || (action.getMethodCoverage().getPercentageFloat() < action.getThresholds().getMinMethod())) {
 			return Result.FAILURE;
 		}
-		if ((action.getBranchCoverage().getPercentage() < action.getThresholds().getMaxBranch()) || (action.getInstructionCoverage().getPercentage() < action.getThresholds().getMaxInstruction())  || (action.getClassCoverage().getPercentage() < action.getThresholds().getMaxClass())  || (action.getLineCoverage().getPercentage() < action.getThresholds().getMaxLine())  || (action.getComplexityScore().getPercentage() < action.getThresholds().getMaxComplexity())  || (action.getMethodCoverage().getPercentage() < action.getThresholds().getMaxMethod())) {
+		if ((action.getBranchCoverage().getPercentageFloat() < action.getThresholds().getMaxBranch()) || (action.getInstructionCoverage().getPercentageFloat() < action.getThresholds().getMaxInstruction())  || (action.getClassCoverage().getPercentageFloat() < action.getThresholds().getMaxClass())  || (action.getLineCoverage().getPercentageFloat() < action.getThresholds().getMaxLine())  || (action.getComplexityScore().getPercentageFloat() < action.getThresholds().getMaxComplexity())  || (action.getMethodCoverage().getPercentageFloat() < action.getThresholds().getMaxMethod())) {
 			return Result.UNSTABLE;
 		}
 		return Result.SUCCESS;

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -183,7 +183,7 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 			
 			if (JacocoHealthReportThresholds.RESULT.BETWEENMINMAX == healthReports.getResultByTypeAndRatio(ratio)) {
 				bgColor = "#FF8000";
-			} else if (JacocoHealthReportThresholds.RESULT.BELLOWMINIMUM == healthReports.getResultByTypeAndRatio(ratio)) {
+			} else if (JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == healthReports.getResultByTypeAndRatio(ratio)) {
 				bgColor = "#FF0000";
 			}
 			buf.append("<td bgcolor='").append(bgColor).append("'");


### PR DESCRIPTION
This eliminates rounding when comparing against the configured coverage thresholds.
99.6% coverage should not pass the build if someone has required 100% coverage.

There's some argument that round() should be replaced with floor() for presentation purposes as well, but this seems like a less controversial starting point.