### PR TITLE
Expand the inclusion and exclusion inputs.

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -472,12 +472,14 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
         logger.println("\n[JaCoCo plugin] Loading inclusions files..");
         String[] includes = {};
         if (inclusionPattern != null) {
-            includes = inclusionPattern.split(DIR_SEP);
+            String expandedInclusion = env.expand(inclusionPattern);
+            includes = expandedInclusion.split(DIR_SEP);
             logger.println("[JaCoCo plugin] inclusions: " + Arrays.toString(includes));
         }
         String[] excludes = {};
         if (exclusionPattern != null) {
-            excludes = exclusionPattern.split(DIR_SEP);
+            String expandedExclusion = env.expand(exclusionPattern);
+            excludes = expandedExclusion.split(DIR_SEP);
             logger.println("[JaCoCo plugin] exclusions: " + Arrays.toString(excludes));
         }
 


### PR DESCRIPTION
In our project, we had to exclude a lot of generated files. These generated files are specific to each project.  So we decided to have a properties file in each repository, which will have the list of generated class files name. This file will be loaded by EnvInject Plugin to set the property in the build context.

In the jacoco plugin configuration, we will use the env variable like this ${JACOCO_EXLUDE_FILES}. 

This PR will make sure, the jacoco plugin expands the variable before using it.  