### PR TITLE
JENKINS-26254 Use BufferedInputStream to read .exec files

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -2,9 +2,11 @@ package hudson.plugins.jacoco;
 
 import hudson.FilePath;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,14 +86,15 @@ public class ExecutionFileLoader implements Serializable {
 			for (FilePath filePath : execFiles) {
 				File executionDataFile = new File(filePath.getRemote());
 				try {
-					final FileInputStream fis = new FileInputStream(executionDataFile);
+					final InputStream inputStream = new BufferedInputStream(
+							new FileInputStream(executionDataFile));
 					try {
-	                    final ExecutionDataReader reader = new ExecutionDataReader(fis);
+	                    final ExecutionDataReader reader = new ExecutionDataReader(inputStream);
 	                    reader.setSessionInfoVisitor(sessionInfoStore);
 	                    reader.setExecutionDataVisitor(executionDataStore);
 	                    reader.read();
 					} finally {
-					    fis.close();
+					    inputStream.close();
 					}
 	            } catch (final IOException e) {
 	            	System.out.println("While reading execution data-file: " + executionDataFile);


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26254

It doesn't seem to make much difference in an unloaded server, but hopefully it will speed up the post-build steps when Jenkins is under load.

EDIT: I've built a copy of the plugin here, if you want to risk it:
[jacoco-plugin.zip](https://github.com/jenkinsci/jacoco-plugin/files/628720/jacoco-plugin.zip)