### PR TITLE
New flag to enable/disable display of source files with line coverage highlights

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -68,6 +68,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
     private String sourcePattern;
     private String inclusionPattern;
     private String exclusionPattern;
+    private boolean skipCopyOfSrcFiles; // Added for enabling/disabling copy of source files
 
     private String minimumInstructionCoverage;
     private String minimumBranchCoverage;
@@ -94,6 +95,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
         this.sourcePattern = "**/src/main/java";
         this.inclusionPattern = "";
         this.exclusionPattern = "";
+        this.skipCopyOfSrcFiles = false;
         this.minimumInstructionCoverage = "0";
         this.minimumBranchCoverage = "0";
         this.minimumComplexityCoverage = "0";
@@ -113,7 +115,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
      * Loads the configuration set by user.
      */
     @Deprecated
-    public JacocoPublisher(String execPattern, String classPattern, String sourcePattern, String inclusionPattern, String exclusionPattern, String maximumInstructionCoverage, String maximumBranchCoverage
+    public JacocoPublisher(String execPattern, String classPattern, String sourcePattern, String inclusionPattern, String exclusionPattern, boolean skipCopyOfSrcFiles, String maximumInstructionCoverage, String maximumBranchCoverage
     		, String maximumComplexityCoverage, String maximumLineCoverage, String maximumMethodCoverage, String maximumClassCoverage, String minimumInstructionCoverage, String minimumBranchCoverage
     		, String minimumComplexityCoverage, String minimumLineCoverage, String minimumMethodCoverage, String minimumClassCoverage, boolean changeBuildStatus) {
     	this.execPattern = execPattern;
@@ -121,6 +123,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
     	this.sourcePattern = sourcePattern;
     	this.inclusionPattern = inclusionPattern;
     	this.exclusionPattern = exclusionPattern;
+        this.skipCopyOfSrcFiles = skipCopyOfSrcFiles;
     	this.minimumInstructionCoverage = minimumInstructionCoverage;
     	this.minimumBranchCoverage = minimumBranchCoverage;
     	this.minimumComplexityCoverage = minimumComplexityCoverage;
@@ -192,7 +195,9 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 		return exclusionPattern;
 	}
 
-
+    public boolean isSkipCopyOfSrcFiles() {
+        return skipCopyOfSrcFiles;
+    }
 
 	public String getMinimumInstructionCoverage() {
 		return minimumInstructionCoverage;
@@ -285,6 +290,11 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
     @DataBoundSetter
     public void setSourcePattern(String sourcePattern) {
         this.sourcePattern = sourcePattern;
+    }
+
+    @DataBoundSetter
+    public void setSkipCopyOfSrcFiles(boolean skipCopyOfSrcFiles) {
+        this.skipCopyOfSrcFiles = skipCopyOfSrcFiles;
     }
 
     @DataBoundSetter
@@ -451,13 +461,18 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
         logger.print("\n[JaCoCo plugin] Saving matched class directories for class-pattern: " + classPattern + ": ");
         for (FilePath file : matchedClassDirs) {
             dir.saveClassesFrom(file);
-            logger.print(" " + file);
         }
-        FilePath[] matchedSrcDirs = resolveDirPaths(filePath, taskListener, sourcePattern);
-        logger.print("\n[JaCoCo plugin] Saving matched source directories for source-pattern: " + sourcePattern + ": ");
-        for (FilePath file : matchedSrcDirs) {
-            dir.saveSourcesFrom(file);
-            logger.print(" " + file);
+
+        // Use skipCopyOfSrcFiles flag to determine if the source files should be copied or skipped. If skipped display appropriate logger message.
+        if(!this.skipCopyOfSrcFiles) {
+            FilePath[] matchedSrcDirs = resolveDirPaths(filePath, taskListener, sourcePattern);
+            logger.print("\n[JaCoCo plugin] Saving matched source directories for source-pattern: " + sourcePattern + ": ");
+            for (FilePath file : matchedSrcDirs) {
+                dir.saveSourcesFrom(file);
+            }
+        }
+        else{
+            logger.print("\n[JaCoCo plugin] Skipping save of matched source directories for source-pattern: " + sourcePattern);
         }
 
         logger.println("\n[JaCoCo plugin] Loading inclusions files..");

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -461,6 +461,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
         logger.print("\n[JaCoCo plugin] Saving matched class directories for class-pattern: " + classPattern + ": ");
         for (FilePath file : matchedClassDirs) {
             dir.saveClassesFrom(file);
+	    logger.print(" " + file);
         }
 
         // Use skipCopyOfSrcFiles flag to determine if the source files should be copied or skipped. If skipped display appropriate logger message.
@@ -469,6 +470,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
             logger.print("\n[JaCoCo plugin] Saving matched source directories for source-pattern: " + sourcePattern + ": ");
             for (FilePath file : matchedSrcDirs) {
                 dir.saveSourcesFrom(file);
+		logger.print(" " + file);
             }
         }
         else{

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
@@ -48,6 +48,10 @@
       </tr>
       </table>
     </f:entry>
+    <!-- Added to allow the user to enable/disable copy of source files -->
+    <f:entry field="skipCopyOfSrcFiles">
+       <f:checkbox checked="${instance.selected}" title="Disable display of source files for coverage"/>
+    </f:entry>
     <f:entry>
 	  <table width="78%">
 	      <col width="12%"/>

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/help-skipCopyOfSrcFiles.html
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/help-skipCopyOfSrcFiles.html
@@ -1,0 +1,3 @@
+<div>
+    Check this to disable display of source files for each line coverage
+</div>

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -46,7 +46,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
     @SuppressWarnings("deprecation")
 	@Test
 	public void testConstruct() {
-		JacocoPublisher publisher = new JacocoPublisher(null, null, null, null, null,
+		JacocoPublisher publisher = new JacocoPublisher(null, null, null, null, null, false,
 				null, null, null, null,
 				null, null, null, null,
 				null, null, null, null,

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -19,6 +19,7 @@ import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.internal.analysis.ClassCoverageImpl;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -333,5 +334,140 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		action.setCoverage(new ClassReport(), covReport);
 
 		assertEquals(Result.SUCCESS, JacocoPublisher.checkResult(action));
+	}
+
+	@Test
+	public void testSkipCopyOfSrcFilesTrue() throws IOException, InterruptedException{
+
+		final Run run = mock(Run.class);
+		expect(run.getEnvironment(taskListener)).andReturn(new EnvVars()).anyTimes();
+		expect(run.getResult()).andReturn(Result.SUCCESS).anyTimes();
+		expect(run.getParent()).andReturn(null).anyTimes();
+
+		// create a test build directory
+		File rootDir = File.createTempFile("BuildTest", ".tst");
+		assertTrue(rootDir.delete());
+		assertTrue(rootDir.mkdirs());
+		FilePath root = new FilePath(rootDir);
+
+		expect(run.getRootDir()).andReturn(rootDir).anyTimes();
+
+		Action action = anyObject();
+		run.addAction(action);
+		final AtomicReference<JacocoBuildAction> buildAction = new AtomicReference<>();
+		expectLastCall().andAnswer(new IAnswer<Void>() {
+			@Override
+			public Void answer() throws Throwable {
+				buildAction.set((JacocoBuildAction) getCurrentArguments()[0]);
+				buildAction.get().onAttached(run);
+
+				return null;
+			}
+		});
+
+		replay(taskListener, run);
+
+		// create a test workspace of Jenkins job
+		File wksp = File.createTempFile("workspace", ".tst");
+		assertTrue(wksp.delete());
+		assertTrue(wksp.mkdir());
+		wksp.deleteOnExit();
+		FilePath workspace = new FilePath(wksp);
+
+		// create class and source files directory inside the test workspace
+		File d1 = new File(workspace.child("classes").getRemote());
+		assertTrue(d1.mkdir());
+		d1.deleteOnExit();
+		File testClass = File.createTempFile("Test", ".class", d1);
+		assertTrue(testClass.delete());
+		assertTrue(testClass.mkdir());
+		testClass.deleteOnExit();
+
+		File d2 = new File(workspace.child("java").getRemote());
+		assertTrue(d2.mkdir());
+		d2.deleteOnExit();
+		File testSrc = File.createTempFile("Test", ".java", d2);
+		assertTrue(testSrc.delete());
+		assertTrue(testSrc.mkdir());
+		testSrc.deleteOnExit();
+
+		// set skip copy of src files as true
+		JacocoPublisher publisher = new JacocoPublisher("**/**.exec", "**/classes", "**/java", null, null, true, null, null
+				, null, null, null, null, null, null
+				, null, null, null, null, false);
+		publisher.perform(run, workspace, launcher, taskListener);
+
+		// verify if jacoco/sources doesn't exists
+		File jacocoSrc = new File(rootDir, "jacoco/sources");
+		Assert.assertFalse(jacocoSrc.exists() && jacocoSrc.isDirectory());
+
+		verify(taskListener, run);
+	}
+
+	@Test
+	public void testSkipCopyOfSrcFilesFalse() throws IOException, InterruptedException{
+
+		final Run run = mock(Run.class);
+		expect(run.getEnvironment(taskListener)).andReturn(new EnvVars()).anyTimes();
+		expect(run.getResult()).andReturn(Result.SUCCESS).anyTimes();
+		expect(run.getParent()).andReturn(null).anyTimes();
+
+		// create a test build directory
+		File rootDir = File.createTempFile("BuildTest", ".tst");
+		assertTrue(rootDir.delete());
+		assertTrue(rootDir.mkdirs());
+		FilePath root = new FilePath(rootDir);
+
+		expect(run.getRootDir()).andReturn(rootDir).anyTimes();
+
+		Action action = anyObject();
+		run.addAction(action);
+		final AtomicReference<JacocoBuildAction> buildAction = new AtomicReference<>();
+		expectLastCall().andAnswer(new IAnswer<Void>() {
+			@Override
+			public Void answer() throws Throwable {
+				buildAction.set((JacocoBuildAction) getCurrentArguments()[0]);
+				buildAction.get().onAttached(run);
+
+				return null;
+			}
+		});
+
+		replay(taskListener, run);
+
+		// create a test workspace of Jenkins job
+		File wksp = File.createTempFile("workspace", ".tst");
+		assertTrue(wksp.delete());
+		assertTrue(wksp.mkdir());
+		wksp.deleteOnExit();
+		FilePath workspace = new FilePath(wksp);
+
+		// create class and source files directory inside the test workspace
+		File d1 = new File(workspace.child("classes").getRemote());
+		assertTrue(d1.mkdir());
+		d1.deleteOnExit();
+		File testClass = File.createTempFile("Test", ".class", d1);
+		assertTrue(testClass.delete());
+		assertTrue(testClass.mkdir());
+		testClass.deleteOnExit();
+
+		File d2 = new File(workspace.child("java").getRemote());
+		assertTrue(d2.mkdir());
+		d2.deleteOnExit();
+		File testSrc = File.createTempFile("Test", ".java", d2);
+		assertTrue(testSrc.delete());
+		assertTrue(testSrc.mkdir());
+		testSrc.deleteOnExit();
+
+		// set skip copy of src files as false
+		JacocoPublisher publisher = new JacocoPublisher("**/**.exec", "**/classes", "**/java", null, null, false, null, null
+				, null, null, null, null, null, null
+				, null, null, null, null, false);
+		publisher.perform(run, workspace, launcher, taskListener);
+
+		// verify if jacoco/sources exists
+		File jacocoSrc = new File(rootDir, "jacoco/sources");
+		assertTrue(jacocoSrc.exists() && jacocoSrc.isDirectory());
+		verify(taskListener, run);
 	}
 }


### PR DESCRIPTION
Added a new flag named "Disable display of source files for coverage" to allow the end-user to choose whether to copy source files or not. This is a required use-case as some applications have thousands of source files and Jacoco plugin consumes lot of time to copy the files to the master node. Users are not always interested in viewing the line coverage highlights in source files specially when the application have thousands or more files. Providing an option will serve the purpose.
![skipcopyofsrcfiles](https://cloud.githubusercontent.com/assets/9617694/23083410/5a0d323a-f512-11e6-8b8b-f975362f0122.png)
