### PR TITLE
Added symbol name for better pipeline integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,11 @@ THE SOFTWARE.
             <artifactId>httpcore</artifactId>
             <version>4.4.1</version>
         </dependency>
+      <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.2</version>
+      </dependency>
    </dependencies>
    
 	<distributionManagement>

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -28,8 +28,10 @@ import java.util.List;
 import java.util.Map;
 
 import jenkins.MasterToSlaveFileCallable;
+import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.tools.ant.DirectoryScanner;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -727,15 +729,20 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 
     @Override
     public BuildStepDescriptor<Publisher> getDescriptor() {
-        return DESCRIPTOR;
+        return (BuildStepDescriptor<Publisher>)super.getDescriptor();
     }
 
-	@Extension
-    public static final BuildStepDescriptor<Publisher> DESCRIPTOR = new DescriptorImpl();
+    /**
+     * @deprecated
+     *      use injection via {@link Jenkins#getInjector()}
+     */
+    public static /*final*/ BuildStepDescriptor<Publisher> DESCRIPTOR;
 
+    @Extension @Symbol("jacoco")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         public DescriptorImpl() {
             super(JacocoPublisher.class);
+            DESCRIPTOR = this;
         }
 
 		@Override

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.*;
+import hudson.plugins.jacoco.JacocoPublisher.DescriptorImpl;
 import org.easymock.IAnswer;
 import org.junit.Before;
 import org.junit.Test;
@@ -148,7 +149,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 
 		assertEquals(BuildStepMonitor.NONE, publisher.getRequiredMonitorService());
 
-		BuildStepDescriptor<Publisher> descriptor = publisher.getDescriptor();
+		BuildStepDescriptor<Publisher> descriptor = new DescriptorImpl();
 		assertNotNull(descriptor);
 		assertNotNull(descriptor.getDisplayName());
 		assertTrue(descriptor.isApplicable(null));


### PR DESCRIPTION
Before:
```
step([$class: 'JacocoPublisher', execPattern: 'target/jacoco.exec'])
```
After:
```
jacoco(execPattern: 'target/jacoco.exec')
```