### PR TITLE
Increased coverage percentage scale up to 6

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/model/Coverage.java
+++ b/src/main/java/hudson/plugins/jacoco/model/Coverage.java
@@ -1,7 +1,9 @@
 package hudson.plugins.jacoco.model;
 
 import java.io.Serializable;
+import java.math.RoundingMode;
 
+import hudson.plugins.jacoco.portlet.utils.Utils;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -55,8 +57,8 @@ final public class Coverage implements Serializable {
      * Gets the percentage as an integer between 0 and 100.
      */
     @Exported
-    public int getPercentage() {
-        return Math.round(getPercentageFloat());
+    public float getPercentage() {
+        return Utils.roundFloat(6, RoundingMode.HALF_EVEN, getPercentageFloat());
     }
 
     /**

--- a/src/test/java/hudson/plugins/jacoco/CoverageTest.java
+++ b/src/test/java/hudson/plugins/jacoco/CoverageTest.java
@@ -13,7 +13,7 @@ public class CoverageTest extends AbstractJacocoTestBase {
 	@Test
     public void testPercentageCalculation() throws Exception {
         Coverage c = new Coverage(1, 2);
-        assertEquals(67, c.getPercentage());
+        assertEquals("Coverage percentage calculation", 66.666667, c.getPercentage(), 0.00001);
     }
 
 	@Test
@@ -38,6 +38,6 @@ public class CoverageTest extends AbstractJacocoTestBase {
 	@Test
     public void testVacuousCoverage() throws Exception {
         final Coverage c = new Coverage(0, 0);
-        assertEquals(100, c.getPercentage());
+        assertEquals("Vacuous coverage percentage calculation", 100.000000, c.getPercentage(), 0.00001);
     }
 }


### PR DESCRIPTION
This change will display coverage percentages on Jenkins UI with scale up to 6. It is useful for large code base having millions of lines of code.