### PR TITLE
JENKINS-43310 add source file inclusions and exclusions

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -73,6 +73,8 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
     private String execPattern;
     private String classPattern;
     private String sourcePattern;
+    private String sourceInclusionPattern;
+    private String sourceExclusionPattern;
     private String inclusionPattern;
     private String exclusionPattern;
     private boolean skipCopyOfSrcFiles; // Added for enabling/disabling copy of source files
@@ -112,6 +114,8 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
         this.execPattern = "**/**.exec";
         this.classPattern = "**/classes";
         this.sourcePattern = "**/src/main/java";
+        this.sourceInclusionPattern = "**/*.java";
+        this.sourceExclusionPattern = "";
         this.inclusionPattern = "";
         this.exclusionPattern = "";
         this.skipCopyOfSrcFiles = false;
@@ -190,8 +194,11 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 	@Override
 	public String toString() {
 		return "JacocoPublisher [execPattern=" + execPattern
-				+ ", classPattern=" + classPattern + ", sourcePattern="
-				+ sourcePattern + ", inclusionPattern=" + inclusionPattern
+				+ ", classPattern=" + classPattern
+				+ ", sourcePattern=" + sourcePattern
+				+ ", sourceExclusionPattern=" + sourceExclusionPattern
+				+ ", sourceInclusionPattern=" + sourceInclusionPattern
+				+ ", inclusionPattern=" + inclusionPattern
 				+ ", exclusionPattern=" + exclusionPattern
 				+ ", minimumInstructionCoverage=" + minimumInstructionCoverage
 				+ ", minimumBranchCoverage=" + minimumBranchCoverage
@@ -227,7 +234,14 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 	public String getSourcePattern() {
 		return sourcePattern;
 	}
-	
+
+	public String getSourceExclusionPattern() {
+		return sourceExclusionPattern;
+	}
+	public String getSourceInclusionPattern() {
+		return sourceInclusionPattern;
+	}
+
 	public String getInclusionPattern() {
 		return inclusionPattern;
 	}
@@ -361,6 +375,16 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
     @DataBoundSetter
     public void setSourcePattern(String sourcePattern) {
         this.sourcePattern = sourcePattern;
+    }
+
+    @DataBoundSetter
+    public void setSourceInclusionPattern(String sourceInclusionPattern) {
+        this.sourceInclusionPattern = sourceInclusionPattern;
+    }
+
+    @DataBoundSetter
+    public void setSourceExclusionPattern(String sourceExclusionPattern) {
+        this.sourceExclusionPattern = sourceExclusionPattern;
     }
 
     @DataBoundSetter
@@ -583,9 +607,11 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
         if(!this.skipCopyOfSrcFiles) {
             FilePath[] matchedSrcDirs = resolveDirPaths(filePath, taskListener, sourcePattern);
             logger.print("\n[JaCoCo plugin] Saving matched source directories for source-pattern: " + sourcePattern + ": ");
+            logger.print("\n[JaCoCo plugin] Source Inclusions: " + sourceInclusionPattern);
+            logger.print("\n[JaCoCo plugin] Source Exclusions: " + sourceExclusionPattern);
             if (hasSubDirectories(sourcePattern)) logger.print(warning);
             for (FilePath dir : matchedSrcDirs) {
-                int copied = reportDir.saveSourcesFrom(dir, "**/*.java");
+                int copied = reportDir.saveSourcesFrom(dir, sourceInclusionPattern, sourceExclusionPattern);
                 logger.print("\n[JaCoCo plugin] - " + dir + " " + copied + " files");
             }
         }

--- a/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
@@ -40,10 +40,10 @@ public class JacocoReportDir {
         return new File(root,"sources");
     }
 
-    public int saveSourcesFrom(@Nonnull FilePath dir, @Nonnull String fileMask) throws IOException, InterruptedException {
+    public int saveSourcesFrom(@Nonnull FilePath dir, @Nonnull String inclusionMask, @Nonnull String exclusionMask) throws IOException, InterruptedException {
         FilePath d = new FilePath(getSourcesDir());
         d.mkdirs();
-        return dir.copyRecursiveTo(fileMask, d);
+        return dir.copyRecursiveTo(inclusionMask, exclusionMask, d);
     }
 
     /**

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
@@ -8,8 +8,8 @@
       <col width="26%"/>
       <tr>
         <td>Path to exec files (e.g.: **/target/**.exec, **/jacoco.exec)</td>
-        <td>Path to class directories (e.g.: **/target/classDir, **/classes)</td>
-        <td>Path to source directories (e.g.: **/mySourceFiles)</td>
+        <td>Inclusions (e.g.: **/*.class)</td>
+        <td>Exclusions (e.g.: **/*Test*.class)</td>
       </tr>
       
       <tr>
@@ -18,32 +18,49 @@
         </td>
       
         <td>
-          <f:textbox field="classPattern"  default="**/classes"/>
-        </td>
-        
-        <td>
-          <f:textbox field="sourcePattern" default="**/src/main/java"/>
-        </td>
-        
-      </tr>
-      </table>
-      <table width="78%">
-            <col width="39%"/>
-      		<col width="39%"/>
-      <tr>
-        <td>Inclusions (e.g.: **/*.class)</td>
-        <td>Exclusions (e.g.: **/*Test*.class)</td>
-      </tr>
-      
-      <tr>
-        <td>
           <f:textbox field="inclusionPattern" default=""/>
+
         </td>
         
         <td>
           <f:textbox field="exclusionPattern" default=""/>
         </td>
       </tr>
+      </table>
+      <br/>
+      <table width="78%">
+        <col width="39%"/>
+        <col width="39%"/>
+        <tr>
+            <td>Path to class directories (e.g.: **/target/classDir, **/classes)</td>
+        </tr>
+        <tr>
+         <td>
+            <f:textbox field="classPattern"  default="**/classes"/>
+         </td>
+        </tr>
+      </table>
+      <br/>
+      <table width="78%">
+        <col width="26%"/>
+        <col width="26%"/>
+        <col width="26%"/>
+        <tr>
+            <td>Path to source directories (e.g.: **/mySourceFiles)</td>
+            <td>Inclusions (e.g.: **/*.java,**/*.groovy,**/*.gs)</td>
+            <td>Exclusions (e.g.: generated/**/*.java)</td>
+        </tr>
+        <tr>
+          <td>
+            <f:textbox field="sourcePattern" default="**/src/main/java"/>
+          </td>
+          <td>
+            <f:textbox field="sourceInclusionPattern" default="**/*.java"/>
+          </td>
+          <td>
+            <f:textbox field="sourceExclusionPattern" default=""/>
+          </td>
+        </tr>
       </table>
     </f:entry>
 


### PR DESCRIPTION
The JaCoCo Plugin 2.2.0 release restricts source files copied to only include .java files. See [JENKINS-38604](https://issues.jenkins-ci.org/browse/JENKINS-38604) and commit [d771e0b](https://github.com/jenkinsci/jacoco-plugin/commit/d771e0b15933516917208f30dd54bad81b1c290d). Preventing other jvm language source files from being processed, such as .groovy, .gs .kt, etc. While coverage statistics are still available coverage is not shown graphically for the files. See the related bug [JENKINS-43310](https://issues.jenkins-ci.org/browse/JENKINS-43310).

This pull request adds configuration properties for source file inclusions and exclusions patterns. Allowing users to configure which files are copied from the sources directory.

It restructures the configuration UI to make it clear that,

- Existing inclusions and exclusions are applied to the .exec file.

- Classes cannot be configured with inclusions and exclusions. 

- Sources can be configured with inclusions exclusions.

<img width="800" alt="Job Configuration" src="https://cloud.githubusercontent.com/assets/2162225/24979970/2570f3f4-1fce-11e7-97aa-979b69010d26.png">

By default the source inclusions is set to `**/*.java` and the exclusions are blank.
