### PR TITLE
Handle build abort (by not catching InterruptedException)

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -126,7 +126,7 @@ public class ExecutionFileLoader implements Serializable {
 				for (final File file : filesToAnalyze) {
 					analyzer.analyzeAll(file);
 				}
-			} catch (final Exception e) {
+			} catch (final RuntimeException e) {
 				System.out.println("While reading class directory: " + classDirectory);
 				e.printStackTrace();
 			}

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -485,40 +485,39 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 		sourceFolder.copyRecursiveTo(destFolder);
 	}
 	
-    protected String resolveFilePaths(Run<?, ?> build, TaskListener listener, String input, Map<String, String> env) {
+    protected String resolveFilePaths(Run<?, ?> build, TaskListener listener, String input, Map<String, String> env)
+            throws InterruptedException {
         try {
-
             final EnvVars environment = build.getEnvironment(listener);
             environment.overrideAll(env);
             return environment.expand(input);
-            
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             listener.getLogger().println("Failed to resolve parameters in string \""+
             input+"\" due to following error:\n"+e.getMessage());
         }
         return input;
     }
 
-    protected String resolveFilePaths(AbstractBuild<?, ?> build, TaskListener listener, String input) {
+    protected String resolveFilePaths(AbstractBuild<?, ?> build, TaskListener listener, String input)
+            throws InterruptedException {
         try {
-
             final EnvVars environment = build.getEnvironment(listener);
             environment.overrideAll(build.getBuildVariables());
             return environment.expand(input);
-
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             listener.getLogger().println("Failed to resolve parameters in string \""+
                     input+"\" due to following error:\n"+e.getMessage());
         }
         return input;
     }
 
-    protected static FilePath[] resolveDirPaths(FilePath workspace, TaskListener listener, final String input) {
+    protected static FilePath[] resolveDirPaths(FilePath workspace, TaskListener listener, final String input)
+            throws InterruptedException {
 		//final PrintStream logger = listener.getLogger();
 		FilePath[] directoryPaths = null;
 		try {
             directoryPaths = workspace.act(new ResolveDirPaths(input));
-		} catch(InterruptedException | IOException ie) {
+		} catch (IOException ie) {
 			ie.printStackTrace();
 		}
         return directoryPaths;

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -100,8 +100,8 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 				}
 			}
 			action.getLogger().println("[JaCoCo plugin] Done.");
-			
-		} catch (Exception e) {
+
+		} catch (RuntimeException e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
Fixes exceptions like this one when build is aborted during the JacocoPublisher step:
```
java.lang.NullPointerException
	at hudson.plugins.jacoco.JacocoPublisher.perform(JacocoPublisher.java:585)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:78)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:65)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1$1.call(SynchronousNonBlockingStepExecution.java:49)
	at hudson.security.ACL.impersonate(ACL.java:213)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution$1.run(SynchronousNonBlockingStepExecution.java:46)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```