### PR TITLE
Fix the Jacoco Coverage Trend portlet

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/portlet/JacocoLoadData.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/JacocoLoadData.java
@@ -31,6 +31,8 @@ package hudson.plugins.jacoco.portlet;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
@@ -50,6 +52,11 @@ import hudson.plugins.jacoco.portlet.utils.Utils;
 public final class JacocoLoadData {
 
   /**
+   * Date formatter.
+   */
+  public static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  /**
    * Private constructor avoiding this class to be used in a non-static way.
    */
   private JacocoLoadData() {
@@ -65,9 +72,9 @@ public final class JacocoLoadData {
    *          number of days
    * @return Map The sorted summaries
    */
-  public static Map<Calendar, JacocoCoverageResultSummary> loadChartDataWithinRange(List<Job<?,?>> jobs, int daysNumber) {
+  public static Map<String, JacocoCoverageResultSummary> loadChartDataWithinRange(List<Job<?,?>> jobs, int daysNumber) {
 
-    Map<Calendar, JacocoCoverageResultSummary> summaries = new HashMap<>();
+    Map<String, JacocoCoverageResultSummary> summaries = new HashMap<>();
 
     // Get the last build (last date) of the all jobs
     Calendar firstDate = Utils.getLastDate(jobs);
@@ -126,12 +133,14 @@ public final class JacocoLoadData {
    * @param job
    *          job from the DashBoard Portlet view
    */
-  private static void summarize(Map<Calendar, JacocoCoverageResultSummary> summaries, Run<?,?> run, Calendar runDate, Job<?,?> job) {
+  private static void summarize(Map<String, JacocoCoverageResultSummary> summaries, Run<?,?> run, Calendar runDate, Job<?,?> job) {
 
     JacocoCoverageResultSummary jacocoCoverageResult = getResult(run);
+	
+	String date = DATE_FORMAT.format(runDate.getTime());
 
     // Retrieve JaCoCo information for informed date
-    JacocoCoverageResultSummary jacocoCoverageResultSummary = summaries.get(runDate);
+    JacocoCoverageResultSummary jacocoCoverageResultSummary = summaries.get(date);
 
     // Consider the last result of each
     // job date (if there are many builds for the same date). If not
@@ -163,7 +172,7 @@ public final class JacocoLoadData {
       }
     }
 
-    summaries.put(runDate, jacocoCoverageResultSummary);
+    summaries.put(date, jacocoCoverageResultSummary);
   }
 
   /**

--- a/src/main/java/hudson/plugins/jacoco/portlet/chart/JacocoBuilderTrendChart.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/chart/JacocoBuilderTrendChart.java
@@ -116,7 +116,7 @@ public class JacocoBuilderTrendChart extends DashboardPortlet {
     List<Job<?,?>> jobs = (List) getDashboard().getJobs();
 
     // Fill a HashMap with the data will be showed in the chart
-    Map<Calendar, JacocoCoverageResultSummary> summaries =
+    Map<String, JacocoCoverageResultSummary> summaries =
             JacocoLoadData.loadChartDataWithinRange(jobs, daysNumber);
 
     return createTrendChart(summaries, width, height);
@@ -134,7 +134,7 @@ public class JacocoBuilderTrendChart extends DashboardPortlet {
    *          the chart height
    * @return Graph (JFreeChart)
    */
-  private static Graph createTrendChart(final Map<Calendar, JacocoCoverageResultSummary> summaries, int widthParam,
+  private static Graph createTrendChart(final Map<String, JacocoCoverageResultSummary> summaries, int widthParam,
     int heightParam) {
 
     return new Graph(-1, widthParam, heightParam) {
@@ -197,11 +197,11 @@ public class JacocoBuilderTrendChart extends DashboardPortlet {
    * @return CategoryDataset Interface for a dataset with one or more
    *         series, and values associated with categories.
    */
-  private static CategoryDataset buildDataSet(Map<Calendar, JacocoCoverageResultSummary> summaries) {
+  private static CategoryDataset buildDataSet(Map<String, JacocoCoverageResultSummary> summaries) {
 
-    DataSetBuilder<String, Calendar> dataSetBuilder = new DataSetBuilder<>();
+    DataSetBuilder<String, String> dataSetBuilder = new DataSetBuilder<>();
 
-    for (Map.Entry<Calendar, JacocoCoverageResultSummary> entry : summaries.entrySet()) {
+    for (Map.Entry<String, JacocoCoverageResultSummary> entry : summaries.entrySet()) {
       float classCoverage = 0;
       float lineCoverage = 0;
       float methodCoverage = 0;


### PR DESCRIPTION
Since the last update (remove joda-time dependency), the jacoco coverage trend chart portlet is broken. The java.util.Calendar toString method does not return a valid date string and the chart is all messed up:

![error](https://cloud.githubusercontent.com/assets/595214/26562305/1c713fc2-4493-11e7-8989-c00d51039036.png)

This fix will format the Calendar into a String ("yyyy-MM-dd") and pass that value to JFreeChart:

![fixed](https://cloud.githubusercontent.com/assets/595214/26562321/4147962a-4493-11e7-85b7-ffe7b5b2a7c5.png)

Regards