### PR TITLE
Improve exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
    </parent>
 
    <artifactId>jacoco</artifactId>
-   <version>2.2.2-SNAPSHOT</version>
+   <version>2.3-SNAPSHOT</version>
    <packaging>hpi</packaging>
 
    <name>Jenkins JaCoCo plugin</name>

--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -93,11 +93,10 @@ public class ExecutionFileLoader implements Serializable {
 						reader.setExecutionDataVisitor(executionDataStore);
 						reader.read();
 					}
-	            } catch (final IOException e) {
-	            	System.out.println("While reading execution data-file: " + executionDataFile);
-	                e.printStackTrace();
-	            }
-	        }
+				} catch (final IOException e) {
+					throw new IOException("While reading execution data-file: " + executionDataFile, e);
+				}
+			}
 		}
 	    private IBundleCoverage analyzeStructure() throws IOException {
 	    	
@@ -121,14 +120,14 @@ public class ExecutionFileLoader implements Serializable {
 
 			final FileFilter fileFilter = new FileFilter(Arrays.asList(includes), Arrays.asList(excludes));
 			try {
-				@SuppressWarnings("unchecked")
 				final List<File> filesToAnalyze = FileUtils.getFiles(classDirectory, fileFilter.getIncludes(), fileFilter.getExcludes());
 				for (final File file : filesToAnalyze) {
 					analyzer.analyzeAll(file);
 				}
-			} catch (final RuntimeException e) {
-				System.out.println("While reading class directory: " + classDirectory);
-				e.printStackTrace();
+			} catch (IOException e) {
+				throw new IOException("While reading class directory: " + classDirectory, e);
+			} catch (RuntimeException e) {
+				throw new RuntimeException("While reading class directory: " + classDirectory, e);
 			}
 			return coverageBuilder.getBundle(name);
 		}

--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -30,6 +30,8 @@ import hudson.plugins.jacoco.model.CoverageElement.Type;
 import hudson.plugins.jacoco.model.CoverageObject;
 import hudson.plugins.jacoco.report.CoverageReport;
 
+import javax.annotation.Nullable;
+
 /**
  * Build view extension by JaCoCo plugin.
  *
@@ -210,8 +212,9 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 
 	/**
 	 * Obtains the detailed {@link CoverageReport} instance.
+	 * @return the report, or null if these was a problem
 	 */
-	public synchronized CoverageReport getResult() {
+	public synchronized @Nullable CoverageReport getResult() {
 
 		if(report!=null) {
 			final CoverageReport r = report.get();
@@ -227,7 +230,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			report = new WeakReference<>(r);
 			r.setThresholds(thresholds);
 			return r;
-		} catch (IOException e) {
+		} catch (IOException | RuntimeException e) {
 			getLogger().println("Failed to load " + reportFolder);
 			e.printStackTrace(getLogger());
 			return null;

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -179,10 +179,9 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
     	}
     	try {
     		String expandedInput = env.expand(input);
-            //noinspection ResultOfMethodCallIgnored
-            return Integer.parseInt(expandedInput);
-    	} catch(NumberFormatException nfe) {
-    		return  THRESHOLD_DEFAULT;
+    		return Integer.parseInt(expandedInput);
+    	} catch (NumberFormatException e) {
+    		return THRESHOLD_DEFAULT;
     	}
     }
 
@@ -486,41 +485,38 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 	}
 	
     protected String resolveFilePaths(Run<?, ?> build, TaskListener listener, String input, Map<String, String> env)
-            throws InterruptedException {
+            throws InterruptedException, IOException {
         try {
             final EnvVars environment = build.getEnvironment(listener);
             environment.overrideAll(env);
             return environment.expand(input);
-        } catch (IOException | RuntimeException e) {
-            listener.getLogger().println("Failed to resolve parameters in string \""+
-            input+"\" due to following error:\n"+e.getMessage());
+        } catch (IOException e) {
+            throw new IOException("Failed to resolve parameters in string \""+
+                    input+"\"", e);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Failed to resolve parameters in string \""+
+                    input+"\"", e);
         }
-        return input;
     }
 
     protected String resolveFilePaths(AbstractBuild<?, ?> build, TaskListener listener, String input)
-            throws InterruptedException {
+            throws InterruptedException, IOException {
         try {
             final EnvVars environment = build.getEnvironment(listener);
             environment.overrideAll(build.getBuildVariables());
             return environment.expand(input);
-        } catch (IOException | RuntimeException e) {
-            listener.getLogger().println("Failed to resolve parameters in string \""+
-                    input+"\" due to following error:\n"+e.getMessage());
+        } catch (IOException e) {
+            throw new IOException("Failed to resolve parameters in string \""+
+                    input+"\"", e);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Failed to resolve parameters in string \""+
+                    input+"\"", e);
         }
-        return input;
     }
 
     protected static FilePath[] resolveDirPaths(FilePath workspace, TaskListener listener, final String input)
-            throws InterruptedException {
-		//final PrintStream logger = listener.getLogger();
-		FilePath[] directoryPaths = null;
-		try {
-            directoryPaths = workspace.act(new ResolveDirPaths(input));
-		} catch (IOException ie) {
-			ie.printStackTrace();
-		}
-        return directoryPaths;
+            throws InterruptedException, IOException {
+		return workspace.act(new ResolveDirPaths(input));
 	}
 
 
@@ -673,7 +669,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
                     convertThresholdInputToInteger(minimumComplexityCoverage, env), 
                     convertThresholdInputToInteger(maximumComplexityCoverage, env)
                 );
-        } catch (NumberFormatException nfe) {
+        } catch (NumberFormatException e) {
             return healthReports = new JacocoHealthReportThresholds(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         }
     }

--- a/src/main/java/hudson/plugins/jacoco/portlet/utils/Utils.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/utils/Utils.java
@@ -77,7 +77,7 @@ public final class Utils {
           return defaultValue;
         }
         return validAttributeValue;
-      } catch (NumberFormatException exception) {
+      } catch (NumberFormatException e) {
         return defaultValue;
       }
     }

--- a/src/main/java/hudson/plugins/jacoco/report/SourceAnnotator.java
+++ b/src/main/java/hudson/plugins/jacoco/report/SourceAnnotator.java
@@ -28,36 +28,31 @@ public class SourceAnnotator {
     /**
      * Parses the source file into individual lines.
      */
-    private List<String> readLines() {
-        ArrayList<String> aList = new ArrayList<>();
-
-        BufferedReader br = null;
-
+    private List<String> readLines() throws IOException {
+        BufferedReader br = new BufferedReader(new FileReader(src));
         try {
-            br = new BufferedReader(new FileReader(src));
+            ArrayList<String> aList = new ArrayList<>();
             String line;
             while ((line = br.readLine()) != null) {
                 aList.add(line.replaceAll("\\t", "&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp").replaceAll("<", "&lt").replaceAll(">", "&gt"));
             }
-        } catch (IOException e) {
-            e.printStackTrace();
+            return aList;
         } finally {
-            if (br != null) {
-                try {
-                    br.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
+            br.close();
         }
-
-        return aList;
     }
 
     public void printHighlightedSrcFile(ISourceNode cov, Writer output) {
-        StringBuilder buf = new StringBuilder();
         try {
-            List<String> sourceLines = readLines();
+            StringBuilder buf = new StringBuilder();
+            List<String> sourceLines;
+            try {
+                sourceLines = readLines();
+            } catch (IOException e) {
+                e.printStackTrace();
+                output.write("ERROR: Error while reading the sourcefile!");
+                return;
+            }
             output.write("<code style=\"white-space:pre;\">");
             for (int i = 1; i <= sourceLines.size(); ++i) {
                 buf.setLength(0);
@@ -76,7 +71,7 @@ public class SourceAnnotator {
 
             //logger.log(Level.INFO, "lines: " + buf);
         } catch (IOException e) {
-            buf.append("ERROR: Error while reading the sourcefile!");
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/hudson/plugins/jacococoveragecolumn/CoverageRange.java
+++ b/src/main/java/hudson/plugins/jacococoveragecolumn/CoverageRange.java
@@ -41,22 +41,23 @@ public enum CoverageRange {
 		return ABYSSMAL;
 	}
 
-	public static Color fillColorOf(final Double amount) {
-		try {
-			for (int i = 0; i < values().length; i++) {
-				final CoverageRange range = values()[i];
-				if (amount == range.floor) {
-					return range.fillColor;
-				} else if (amount > range.floor) {
-					final CoverageRange range1 = values()[i - 1];
-					final double t0 = amount - range.floor;
-					final double t1 = range1.floor - amount;
-					return blendedColor(range.fillColor, range1.fillColor, t0,
-							t1);
+	public static Color fillColorOf(final double amount) {
+		for (int i = 0; i < values().length; i++) {
+			final CoverageRange range = values()[i];
+			if (amount == range.floor) {
+				return range.fillColor;
+			} else if (amount > range.floor) {
+				if (i == 0) {
+					// This method used to throw ArrayIndexOutOfBoundsException
+					// in this case, catch it and return this value:
+					return ABYSSMAL.fillColor;
 				}
+				final CoverageRange range1 = values()[i - 1];
+				final double t0 = amount - range.floor;
+				final double t1 = range1.floor - amount;
+				return blendedColor(range.fillColor, range1.fillColor, t0,
+						t1);
 			}
-		} catch (final RuntimeException e) {
-			return ABYSSMAL.fillColor;
 		}
 		return ABYSSMAL.fillColor;
 	}
@@ -64,6 +65,9 @@ public enum CoverageRange {
 	private static Color blendedColor(final Color fillColor0,
 			final Color fillColor1, final double t0, final double t1) {
 		final double total = t0 + t1;
+		if (total == 0) {
+			return ABYSSMAL.fillColor;
+		}
 		final int r = (int) ((fillColor0.getRed() * t1 + fillColor1.getRed()
 				* t0) / total);
 		final int g = (int) ((fillColor0.getGreen() * t1 + fillColor1

--- a/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
+++ b/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
@@ -104,16 +104,32 @@ public class ExecutionFileLoaderTest {
         loader.setExcludes("excludme.test");
         loader.addExecFile(new FilePath(new File("target/jacoco.exec")));
         
-        // handles invalid files gracefully
-        loader.addExecFile(new FilePath(new File("somenonexistingfile")));
-
         IBundleCoverage coverage = loader.loadBundleCoverage();
         assertNotNull(coverage);
         assertTrue("Expect to have at least some lines found, but had: " + coverage.getClassCounter(), 
                 coverage.getClassCounter().getMissedCount() > 0 ||
                 coverage.getClassCounter().getCoveredCount() > 0);
     }
-    
+
+    @Test
+    public void testLoadBundleWithMissingExecFile() throws IOException {
+        ExecutionFileLoader loader = new ExecutionFileLoader();
+
+        assertTrue("This test requires that a jacoco.exec file exists in the target-directory",
+                new File("target/jacoco.exec").exists());
+        loader.setClassDir(new FilePath(new File("target/classes")));
+        loader.setExcludes("excludme.test");
+        // should report missing file
+        loader.addExecFile(new FilePath(new File("somenonexistingfile")));
+
+        try {
+            loader.loadBundleCoverage();
+            fail("expected IOException");
+        } catch (IOException ignore) {
+            // expected
+        }
+    }
+
     @Test
     public void testLoadBundleWithoutClasses() throws IOException {
         // Special Jenkins publisher case to handle empty classes dir

--- a/src/test/java/hudson/plugins/jacoco/JacocoBuildActionTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoBuildActionTest.java
@@ -8,19 +8,23 @@ import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static java.nio.file.Files.createDirectories;
 import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class JacocoBuildActionTest extends AbstractJacocoTestBase {
+    private static final Logger logger = Logger.getLogger(JacocoBuildActionTest.class.getName());
+
     @Test
     public void testConstruct() throws Exception {
-        Logger logger = Logger.getLogger(this.getClass().getName());
+        File testDir =  new File("target/test/JacocoBuildActionTest");
+        createDirectories(new File(testDir, "jacoco/classes").toPath());
         JacocoBuildAction r = JacocoBuildAction.load(null,
                 new JacocoHealthReportThresholds(30, 90, 25, 80, 15, 60, 15, 60, 20, 70, 0, 0),
                 new LogTaskListener(logger, Level.INFO),
-                new JacocoReportDir(new File(".")), null, null);
+                new JacocoReportDir(testDir), null, null);
         assertNotNull(r);
     }
 

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -55,6 +55,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JacocoPublisher.class)
@@ -207,9 +208,11 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 
 		EasyMock.replay(run, listener);
 
-		assertEquals("input${key}input", publisher.resolveFilePaths(run, listener, "input${key}input", Collections.singletonMap("key", "value")));
-
-		EasyMock.verify(run, listener);
+		try {
+			publisher.resolveFilePaths(run, listener, "input${key}input", Collections.singletonMap("key", "value"));
+		} catch (RuntimeException e) {
+			assertTrue(e.getMessage().startsWith("Failed to resolve parameters"));
+		}
 	}
 
 	@Test
@@ -255,9 +258,12 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 
 		EasyMock.replay(build, listener);
 
-		assertEquals("input${key}input", publisher.resolveFilePaths(build, listener, "input${key}input"));
-
-		EasyMock.verify(build, listener);
+		try {
+			publisher.resolveFilePaths(build, listener, "input${key}input");
+			fail();
+		} catch (RuntimeException e) {
+			assertTrue(e.getMessage().startsWith("Failed to resolve parameters"));
+		}
 	}
 
 	@Test

--- a/src/test/java/hudson/plugins/jacoco/report/AbstractReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/AbstractReportTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.jacoco.report;
 
 import static org.junit.Assert.*;
 import hudson.model.TaskListener;
+import hudson.plugins.jacoco.ExecutionFileLoader;
 import hudson.plugins.jacoco.JacocoBuildAction;
 
 import hudson.util.StreamTaskListener;
@@ -24,7 +25,7 @@ public class AbstractReportTest {
         TaskListener taskListener = StreamTaskListener.fromStdout();
 
         JacocoBuildAction action = new JacocoBuildAction(null, null, taskListener, null, null);
-        report.getParent().getParent().setParent(new CoverageReport(action, null));
+        report.getParent().getParent().setParent(new CoverageReport(action, new ExecutionFileLoader()));
         assertNull(report.getBuild());
 
         assertNull(report.getName());

--- a/src/test/java/hudson/plugins/jacoco/report/ClassReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/ClassReportTest.java
@@ -46,7 +46,7 @@ public class ClassReportTest {
         report.printHighlightedSrcFile(writer);
         
         String string = writer.toString();
-        assertTrue(string, string.contains("</code>"));
+        assertEquals("ERROR: Error while reading the sourcefile!", string);
     }
     
     @Test

--- a/src/test/java/hudson/plugins/jacoco/report/MethodReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/MethodReportTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 public class MethodReportTest {
     @Test
-    public void test() {
+    public void testMissingFile() {
         MethodReport report = new MethodReport();
         assertFalse(report.hasClassCoverage());
         
@@ -22,7 +22,7 @@ public class MethodReportTest {
         StringWriter writer = new StringWriter();
         report.printHighlightedSrcFile(writer);
         String string = writer.toString();
-        assertTrue(string, string.contains("</code>"));
+        assertEquals("ERROR: Error while reading the sourcefile!", string);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jacoco/report/SourceAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/SourceAnnotatorTest.java
@@ -61,7 +61,7 @@ public class SourceAnnotatorTest {
     }
 
     @Test
-    public void testInvalidFile() throws Exception {
+    public void testMissingFile() throws Exception {
         File file = new File("notexisting");
         assertFalse(file.exists());
         SourceAnnotator annotator = new SourceAnnotator(file);
@@ -72,7 +72,7 @@ public class SourceAnnotatorTest {
             annotator.printHighlightedSrcFile(cov, writer);
         }
         String string = new String(out.toByteArray());
-        assertEquals("<code style=\"white-space:pre;\"></code>", string);
+        assertEquals("ERROR: Error while reading the sourcefile!", string);
     }
 
 

--- a/src/test/java/hudson/plugins/jacococoveragecolumn/CoverageRangeTest.java
+++ b/src/test/java/hudson/plugins/jacococoveragecolumn/CoverageRangeTest.java
@@ -23,12 +23,6 @@ public class CoverageRangeTest {
 	}
 
 	@Test
-	public void testFillColorOfHandlesNull() throws Exception {
-		final Color color = CoverageRange.fillColorOf(null);
-		assertEquals(CoverageRange.ABYSSMAL.getFillColor(), color);
-	}
-	
-	@Test
 	public void test() {
 		expect(CoverageRange.ABYSSMAL, -20.0);
 		expect(CoverageRange.ABYSSMAL, 0.0);


### PR DESCRIPTION
@centic9 I've had a go at the changes we discussed in https://github.com/jenkinsci/jacoco-plugin/pull/86/

A number of tests have been "taking advantage" of the lenient error handling, which means that they were eg failing to pass in required files, and then just testing that a non-null report was generated. (This now produces an exception.) In some cases, that's the only test there was! I don't have the knowledge of the code to generate these required files and make more useful tests, but I've tried to ensure that nothing is tested any less than it was before.

I've also ensured that every place which used to catch an exception and log some sort of context, such as a filename, will now capture that context in a wrapper exception. This does mean that the code didn't quite become as simple as I had hoped, but it also means that all the useful error information is preserved.