### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -67,6 +67,13 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 	 *            The available coverage ratios in the report. Null is treated
 	 *            the same as an empty map.
 	 * @param thresholds
+	 *            The thresholds that applied when this build was built.
+	 * @param listener
+	 *            The listener from which we get logger
+	 * @param inclusions
+	 *            See {@link JacocoReportDir#parse(String[], String...)}
+	 * @param exclusions
+	 *            See {@link JacocoReportDir#parse(String[], String...)}
 	 */
 	public JacocoBuildAction(
 			Map<CoverageElement.Type, Coverage> ratios,
@@ -296,7 +303,19 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 
 	/**
 	 * Constructs the object from JaCoCo exec files.
-	 *
+	 * @param owner
+	 *            Not used
+     * @param thresholds
+     *            The thresholds that applied when this build was built.
+     * @param listener
+     *            The listener from which we get logger
+	 * @param layout
+	 *             The object parsing the saved "jacoco.exec" files 
+     * @param includes
+     *            See {@link JacocoReportDir#parse(String[], String...)}
+     * @param excludes
+     *            See {@link JacocoReportDir#parse(String[], String...)}
+	 * @return new {@code JacocoBuildAction} from JaCoCo exec files
 	 * @throws IOException
 	 *      if failed to parse the file.
 	 */
@@ -311,11 +330,6 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 
 	/**
 	 * Extracts top-level coverage information from the JaCoCo report document.
-	 * 
-	 * @param layout
-	 * @param ratios
-	 * @return
-	 * @throws IOException
 	 */
 	private static Map<Type, Coverage> loadRatios(JacocoReportDir layout, Map<Type, Coverage> ratios, String[] includes, String... excludes) throws IOException {
 

--- a/src/main/java/hudson/plugins/jacoco/JacocoProjectAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoProjectAction.java
@@ -36,6 +36,7 @@ public final class JacocoProjectAction implements Action {
 
     /**
      * Gets the most recent {@link JacocoBuildAction} object.
+     * @return the most recent jacoco coverage report
      */
     public JacocoBuildAction getLastResult() {
         for (Run<?, ?> b = project.getLastBuild(); b != null; b = b.getPreviousBuild()) {

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -139,6 +139,32 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 
 	/**
      * Loads the configuration set by user.
+	 * @param execPattern deprecated
+	 * @param classPattern deprecated 
+	 * @param sourcePattern deprecated
+	 * @param inclusionPattern deprecated
+	 * @param exclusionPattern deprecated
+	 * @param skipCopyOfSrcFiles deprecated
+	 * @param maximumInstructionCoverage deprecated
+	 * @param maximumBranchCoverage deprecated
+	 * @param maximumComplexityCoverage deprecated
+	 * @param maximumLineCoverage deprecated
+	 * @param maximumMethodCoverage deprecated
+	 * @param maximumClassCoverage deprecated
+	 * @param minimumInstructionCoverage deprecated
+	 * @param minimumBranchCoverage deprecated
+	 * @param minimumComplexityCoverage deprecated
+	 * @param minimumLineCoverage deprecated
+	 * @param minimumMethodCoverage deprecated
+	 * @param minimumClassCoverage deprecated
+	 * @param changeBuildStatus deprecated
+	 * @param deltaInstructionCoverage deprecated
+	 * @param deltaBranchCoverage deprecated
+	 * @param deltaComplexityCoverage deprecated
+	 * @param deltaLineCoverage deprecated
+	 * @param deltaMethodCoverage deprecated
+	 * @param deltaClassCoverage deprecated
+	 * @param buildOverBuild deprecated
      */
     @Deprecated
     public JacocoPublisher(String execPattern, String classPattern, String sourcePattern, String inclusionPattern, String exclusionPattern, boolean skipCopyOfSrcFiles, String maximumInstructionCoverage, String maximumBranchCoverage

--- a/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
@@ -22,6 +22,7 @@ public class JacocoReportDir {
 
     /**
      * Where we store *.class files, honoring package names as directories.
+     * @return Directory to which we store *.class files, honoring package names as directories.
      */
     public File getClassesDir() {
         return new File(root,"classes");
@@ -35,6 +36,7 @@ public class JacocoReportDir {
 
     /**
      * Where we store *.java files, honoring package names as directories.
+     * @return Directory to which we store *.java files, honoring package names as directories.
      */
     public File getSourcesDir() {
         return new File(root,"sources");
@@ -49,6 +51,7 @@ public class JacocoReportDir {
     /**
      * Root directory that stores jacoco.exec files.
      * Each exec file is stored in its own directory.
+     * @return Directory that stores jacoco.exec files.
      *
      * @see #getExecFiles()
      */
@@ -58,6 +61,7 @@ public class JacocoReportDir {
 
     /**
      * Lists up existing jacoco.exec files.
+     * @return List of existing jacoco.exec files.
      */
     public List<File> getExecFiles() {
         List<File> r = new ArrayList<>();
@@ -88,6 +92,10 @@ public class JacocoReportDir {
 
     /**
      * Parses the saved "jacoco.exec" files into an {@link ExecutionFileLoader}.
+     * @param includes see {@link ExecutionFileLoader#setIncludes}
+     * @param excludes see {@link ExecutionFileLoader#setExcludes}
+     * @return the configured {@code ExecutionFileLoader}
+     * @throws IOException if any I/O error occurs
      */
     public ExecutionFileLoader parse(String[] includes, String... excludes) throws IOException {
         ExecutionFileLoader efl = new ExecutionFileLoader();

--- a/src/main/java/hudson/plugins/jacoco/model/Coverage.java
+++ b/src/main/java/hudson/plugins/jacoco/model/Coverage.java
@@ -53,6 +53,8 @@ final public class Coverage implements Serializable {
 
     /**
      * Gets the percentage as an integer between 0 and 100.
+     * @return the coverage percentage as a rounded integer between 0 and 100.
+     * @see #getPercentageFloat()
      */
     @Exported
     public int getPercentage() {
@@ -61,6 +63,8 @@ final public class Coverage implements Serializable {
 
     /**
      * Gets the percentage as a float between 0f and 100f.
+     * @return the coverage percentage as a float between 0f and 100f.
+     * @see #getPercentage()
      */
     @Exported
     public float getPercentageFloat() {

--- a/src/main/java/hudson/plugins/jacoco/model/CoverageElement.java
+++ b/src/main/java/hudson/plugins/jacoco/model/CoverageElement.java
@@ -59,6 +59,7 @@ public final class CoverageElement {
        * Returns the ratio object on the given report that tracks this type of coverage.
        * 
        * @param from The report to return the appropriate Coverage object from. Not null.
+       * @return the ratio object on the given report that tracks this type of coverage.
        */
       public abstract Coverage getAssociatedRatio(AbstractReport<?,?> from);
     }
@@ -73,6 +74,7 @@ public final class CoverageElement {
      * <p>
      * Warning: don't call this method getType() because that confuses the
      * Digester.
+     * @return the enum constant that says what type of coverage this bean represents.
      */
     public Type getTypeAsEnum() {
         return type;

--- a/src/main/java/hudson/plugins/jacoco/model/CoverageObject.java
+++ b/src/main/java/hudson/plugins/jacoco/model/CoverageObject.java
@@ -48,6 +48,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  *
  * @author Kohsuke Kawaguchi
  * @author Martin Heinzerling
+ * @param <SELF> self-type
  */
 @ExportedBean
 public abstract class CoverageObject<SELF extends CoverageObject<SELF>> {
@@ -198,6 +199,7 @@ public abstract class CoverageObject<SELF extends CoverageObject<SELF>> {
 
 	/**
 	 * Line coverage. Can be null if this information is not collected.
+	 * @return Line coverage.
 	 */
 	@Exported(inline=true)
 	public Coverage getLineCoverage() {
@@ -206,6 +208,7 @@ public abstract class CoverageObject<SELF extends CoverageObject<SELF>> {
 
 	/**
 	 * Gets the build object that owns the whole coverage report tree.
+	 * @return the build object that owns the whole coverage report tree.
 	 */
 	public abstract Run<?,?> getBuild();
 
@@ -223,6 +226,7 @@ public abstract class CoverageObject<SELF extends CoverageObject<SELF>> {
 
 	/**
 	 * Used in the view to print out four table columns with the coverage info.
+	 * @return HTML code.
 	 */
 	public String printFourCoverageColumns() {
 		StringBuilder buf = new StringBuilder();
@@ -358,6 +362,9 @@ public abstract class CoverageObject<SELF extends CoverageObject<SELF>> {
 
 	/**
 	 * Generates the graph that shows the coverage trend up to this report.
+	 * @param req Stapler request from which context, graph width and graph height are read
+	 * @param rsp Stapler response to which is sent the graph
+	 * @throws IOException if any I/O error occurs
 	 */
 	public void doGraph(StaplerRequest req, StaplerResponse rsp) throws IOException {
 		if(ChartUtil.awtProblemCause != null) {

--- a/src/main/java/hudson/plugins/jacoco/portlet/bean/JacocoCoverageResultSummary.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/bean/JacocoCoverageResultSummary.java
@@ -94,7 +94,13 @@ public class JacocoCoverageResultSummary {
    * @param methodCoverage
    *          method coverage percentage
    * @param classCoverage
-   *          coverage percentage
+   *          class coverage percentage
+   * @param branchCoverage
+   *          branch coverage percentage
+   * @param instructionCoverage 
+   *          instruction coverage percentage
+   * @param complexityScore 
+   *          complexity score (not a percentage)
    */
   public JacocoCoverageResultSummary(Job<?,?> job, float lineCoverage, float methodCoverage,
     float classCoverage, float branchCoverage, float instructionCoverage, float complexityScore) {

--- a/src/main/java/hudson/plugins/jacoco/portlet/utils/Utils.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/utils/Utils.java
@@ -142,6 +142,9 @@ public final class Utils {
    * Failure AND Failure = Failure
    * X AND Failure = Failure, Failure AND X = Failure, X = Success/Unstable/Failure
    * Y AND Unstable = Unstable, Unstable AND Y = Unstable, Y = Success/Unstable
+   * @param op1 first result 
+   * @param op2 second result
+   * @return Logical AND operation of {@code op1 AND op2}
    */
   public static Result applyLogicalAnd(Result op1, Result op2){
 

--- a/src/main/java/hudson/plugins/jacoco/report/AbstractReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/AbstractReport.java
@@ -12,6 +12,8 @@ import java.io.IOException;
  * which maintains the details of the coverage report.
  *
  * @author Kohsuke Kawaguchi
+ * @param <PARENT> Parent type
+ * @param <SELF> Self type
  */
 public abstract class AbstractReport<PARENT extends AggregatedReport<?,PARENT,?>,
     SELF extends CoverageObject<SELF>> extends CoverageObject<SELF> implements ModelObject {
@@ -39,6 +41,7 @@ public abstract class AbstractReport<PARENT extends AggregatedReport<?,PARENT,?>
     /**
      * Called at the last stage of the tree construction,
      * to set the back pointer.
+     * @param p parent
      */
     protected void setParent(PARENT p) {
         this.parent = p;

--- a/src/main/java/hudson/plugins/jacoco/report/AggregatedReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/AggregatedReport.java
@@ -11,6 +11,9 @@ import java.util.TreeMap;
  * Reports that have children.
  *
  * @author Kohsuke Kawaguchi
+ * @param <PARENT> Parent type
+ * @param <SELF> Self type
+ * @param <CHILD> Child type
  */
 public abstract class AggregatedReport<PARENT extends AggregatedReport<?,PARENT,?>,
     SELF extends AggregatedReport<PARENT,SELF,CHILD>,

--- a/src/main/java/hudson/plugins/jacoco/report/ClassReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/ClassReport.java
@@ -32,6 +32,7 @@ public final class ClassReport extends AggregatedReport<PackageReport,ClassRepor
 
     /**
      * Read the source Java file for this class.
+     * @return the source Java file for this class.
      */
     public File getSourceFilePath() {
         return new File(sourceFilePath);

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -55,8 +55,8 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 	/**
 	 * Loads the exec files using JaCoCo API. Creates the reporting objects and the report tree.
 	 * 
-	 * @param action
-	 * @param executionFileLoader
+	 * @param action Jacoco build action
+	 * @param executionFileLoader execution file loader owning bundle coverage
 	 */
 	public CoverageReport(JacocoBuildAction action, @Nonnull ExecutionFileLoader executionFileLoader ) {
 		this(action);
@@ -219,6 +219,8 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 
     /**
      * Serves a single jacoco.exec file that merges all that have been recorded.
+     * @return HTTP response serving a single jacoco.exec file, or error 404 if nothing has been recorded. 
+     * @throws IOException if any I/O error occurs
      */
     @WebMethod(name="jacoco.exec")
     public HttpResponse doJacocoExec() throws IOException {

--- a/src/test/java/hudson/plugins/jacoco/CoverageReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/CoverageReportTest.java
@@ -30,6 +30,7 @@ public class CoverageReportTest extends AbstractJacocoTestBase {
 
     /**
      * Ensures the coverage after loading two reports represents the combined metrics of both reports.
+     * @throws Exception if any error occurs
      */
 	@Test
     public void testLoadMultipleReports() throws Exception {


### PR DESCRIPTION
The Maven plugins updates cause a bunch of warnings (68) due to the new version of maven-javadoc-plugin. This PR silences them.