### PR TITLE
Add option to remove original exec file

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
@@ -76,7 +76,7 @@ public class JacocoReportDir {
         return r;
     }
 
-    public void addExecFiles(Iterable<FilePath> execFiles) throws IOException, InterruptedException {
+    public void addExecFiles(Iterable<FilePath> execFiles, boolean removeOriginalExecFiles) throws IOException, InterruptedException {
         FilePath root = new FilePath(getExecFilesDir());
         int i=0;
         for (FilePath file : execFiles) {
@@ -87,6 +87,10 @@ public class JacocoReportDir {
 
         	FilePath fullExecName = separateExecDir.child("jacoco.exec");
         	file.copyTo(fullExecName);
+
+            if (removeOriginalExecFiles) {
+                file.delete();
+            }
         }
     }
 

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
@@ -47,6 +47,10 @@
       </table>
     </f:entry>
 
+	<f:entry field="removeOriginalExecFiles">
+	    <f:checkbox checked="${instance.selected}" title="Remove original exec files after they have been copied to the build job"/>
+	</f:entry>
+
     <!-- Allow the user to enable/disable copy of source files -->
     <f:entry field="skipCopyOfSrcFiles">
        <f:checkbox checked="${instance.selected}" title="Disable display of source files for coverage"/>

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -80,7 +80,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
     @SuppressWarnings("deprecation")
 	@Test
 	public void testConstruct() {
-		JacocoPublisher publisher = new JacocoPublisher(null, null, null, null, null, false,
+		JacocoPublisher publisher = new JacocoPublisher(null, null, null, null, null, false, false,
 				null, null, null, null,
 				null, null, null, null,
 				null, null, null, null,
@@ -145,6 +145,12 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 
 		publisher.setMinimumMethodCoverage("minM");
 		assertEquals("minM", publisher.getMinimumMethodCoverage());
+
+		publisher.setBuildOverBuild(true);
+		assertEquals(true, publisher.isBuildOverBuild());
+
+		publisher.setRemoveOriginalExecFiles(true);
+		assertEquals(true, publisher.getRemoveOriginalExecFiles());
 
 		assertNotNull(publisher.toString());
 
@@ -297,14 +303,14 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		assertTrue(f4.renameTo(f6));
 		f5.deleteOnExit();
 		f6.deleteOnExit();
-		
+
 		/*
-		// Look for files in the entire workspace recursively without providing 
+		// Look for files in the entire workspace recursively without providing
 		// the includes parameter
 		FilePath[] reports = JacocoPublisher.locateCoverageReports(workspace, "**e/jacoco*.xml");
 		assertEquals(2 , reports.length);
 
-		// Generate a includes string and look for files 
+		// Generate a includes string and look for files
 		String includes = f1.getName() + "; " + f2.getName() + "; " + d1.getName();
 		reports = JacocoPublisher.locateCoverageReports(workspace, includes);
 		assertEquals(3, reports.length);
@@ -313,7 +319,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		FilePath local = workspace.child("coverage_localfolder");
 		JacocoPublisher.saveCoverageReports(local, reports);
 		assertEquals(3, local.list().size());
-		
+
 		local.deleteRecursive();
 		 */
 
@@ -500,7 +506,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		PowerMock.replay(taskListener, run, job);
 
 		// execute
-		JacocoPublisher publisher = new JacocoPublisher("**/**.exec", "**/classes", "**/src/main/java", "", "", false, "0", "0"
+		JacocoPublisher publisher = new JacocoPublisher("**/**.exec", "**/classes", "**/src/main/java", "", "", false, false, "0", "0"
 				, "0", "0", "0", "0", "0", "0"
 				, "0", "0", "0", "0", false,
 				"10.564", "5.65", "9.995", "11.4529", "9.346", "5.237", true);


### PR DESCRIPTION
Build parameter that would trigger the removal of the
original exec file after it has been copied to the build
job directory. Default setting being false, hence not
backward incompatible in regards of behavior.

The use-case being that an exec file that has been fetched
from a jacoco-agent can be quite huge, and would also only
be valid until the job has finished. Being that a copy
exists in the build directory already it seems unnecessary
to keep the original in the workspace.

Added test in JacocoPublisherTest::testGetterSetter, also
added a missing test for setBuildOverBuild/isBuildOverBuild.

A bunch of unnecessary whitespaces was also removed...