### PR TITLE
Option to use symlinks for source and classes

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -45,15 +45,15 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
     private static final long serialVersionUID = 1L;
 
 	private transient Run<?,?> owner;
-	
+
 	@Deprecated public transient AbstractBuild<?,?> build;
-	
+
 	private final transient PrintStream logger;
 	@Deprecated private transient ArrayList<?> reports;
 	private transient WeakReference<CoverageReport> report;
 	private final String[] inclusions;
 	private final String[] exclusions;
- 
+
 	/**
 	 * The thresholds that applied when this build was built.
 	 * TODO: add ability to trend thresholds on the graph
@@ -62,7 +62,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 	private transient JacocoProjectAction jacocoProjectAction;
 
 	/**
-	 * 
+	 *
 	 * @param ratios
 	 *            The available coverage ratios in the report. Null is treated
 	 *            the same as an empty map.
@@ -238,7 +238,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			report = new WeakReference<>(r);
 			r.setThresholds(thresholds);
 			return r;
-		} catch (IOException | RuntimeException e) {
+		} catch (IOException | RuntimeException | InterruptedException e) {
 			getLogger().println("Failed to load " + reportFolder);
 			e.printStackTrace(getLogger());
 			return null;
@@ -264,13 +264,13 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 			Coverage lineCoverage = result.getLineCoverage();
 			Coverage methodCoverage = result.getMethodCoverage();
 
-			instructionCoverage.setType(CoverageElement.Type.INSTRUCTION);			
+			instructionCoverage.setType(CoverageElement.Type.INSTRUCTION);
 			classCoverage.setType(CoverageElement.Type.CLASS);
-			complexityScore.setType(CoverageElement.Type.COMPLEXITY);			
-			branchCoverage.setType(CoverageElement.Type.BRANCH);			
+			complexityScore.setType(CoverageElement.Type.COMPLEXITY);
+			branchCoverage.setType(CoverageElement.Type.BRANCH);
 			lineCoverage.setType(CoverageElement.Type.LINE);
 			methodCoverage.setType(CoverageElement.Type.METHOD);
-			
+
 			ratios.put(instructionCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(instructionCoverage));
 			ratios.put(branchCoverage,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(branchCoverage));
 			ratios.put(complexityScore,JacocoHealthReportThresholds.RESULT.BELOWMINIMUM == thresholds.getResultByTypeAndRatio(complexityScore));
@@ -280,7 +280,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 		}
 		return ratios;
 	}
-	
+
 	/**
 	 * Gets the previous {@link JacocoBuildAction} of the given build.
 	 */
@@ -310,19 +310,19 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
      * @param listener
      *            The listener from which we get logger
 	 * @param layout
-	 *             The object parsing the saved "jacoco.exec" files 
+	 *             The object parsing the saved "jacoco.exec" files
      * @param includes
      *            See {@link JacocoReportDir#parse(String[], String...)}
      * @param excludes
      *            See {@link JacocoReportDir#parse(String[], String...)}
 	 * @return new {@code JacocoBuildAction} from JaCoCo exec files
-	 * @throws IOException
-	 *      if failed to parse the file.
+	 * @throws IOException if failed to parse the file.
+	 * @throws InterruptedException if thread is interrupted
 	 */
-	public static JacocoBuildAction load(Run<?,?> owner, JacocoHealthReportThresholds thresholds, TaskListener listener, JacocoReportDir layout, String[] includes, String[] excludes) throws IOException {
+	public static JacocoBuildAction load(Run<?,?> owner, JacocoHealthReportThresholds thresholds, TaskListener listener, JacocoReportDir layout, String[] includes, String[] excludes) throws IOException, InterruptedException {
 		//PrintStream logger = listener.getLogger();
 		Map<CoverageElement.Type,Coverage> ratios = null;
-		
+
 	    ratios = loadRatios(layout, ratios, includes, excludes);
 		return new JacocoBuildAction(ratios, thresholds, listener, includes, excludes);
 	}
@@ -330,8 +330,9 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 
 	/**
 	 * Extracts top-level coverage information from the JaCoCo report document.
+	 * @throws InterruptedException if thread is interrupted
 	 */
-	private static Map<Type, Coverage> loadRatios(JacocoReportDir layout, Map<Type, Coverage> ratios, String[] includes, String... excludes) throws IOException {
+	private static Map<Type, Coverage> loadRatios(JacocoReportDir layout, Map<Type, Coverage> ratios, String[] includes, String... excludes) throws IOException, InterruptedException {
 
 		if (ratios == null) {
 			ratios = new LinkedHashMap<CoverageElement.Type, Coverage>();
@@ -365,7 +366,7 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
 		return ratios;
 
 	}
-	
+
 	//private static final Logger logger = Logger.getLogger(JacocoBuildAction.class.getName());
 	public final PrintStream getLogger() {
 	    if(logger != null) {

--- a/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
@@ -1,11 +1,18 @@
 package hudson.plugins.jacoco;
 
 import hudson.FilePath;
+import hudson.model.TaskListener;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -34,6 +41,21 @@ public class JacocoReportDir {
         return dir.copyRecursiveTo(fileMask, d);
     }
 
+    public Entry<FilePath, FilePath> symlinkClassesFrom(@Nonnull FilePath source, @Nonnull String fileMask, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        FilePath destination = new FilePath(getClassesDir());
+        destination.mkdirs();
+
+        source = this.removeMaskFromPath(source, fileMask);
+        String child = "";
+        if (!destination.getBaseName().equals(source.getBaseName())) {
+            child = source.getBaseName();
+        }
+        destination = new FilePath(new File(destination.getRemote(), child));
+        destination.symlinkTo(source.getRemote(), listener);
+
+        return new AbstractMap.SimpleEntry<FilePath, FilePath>(source, destination);
+    }
+
     /**
      * Where we store *.java files, honoring package names as directories.
      * @return Directory to which we store *.java files, honoring package names as directories.
@@ -46,6 +68,61 @@ public class JacocoReportDir {
         FilePath d = new FilePath(getSourcesDir());
         d.mkdirs();
         return dir.copyRecursiveTo(fileMask, d);
+    }
+
+    public Entry<FilePath, FilePath> symlinkSourcesFrom(@Nonnull FilePath source, @Nonnull String fileMask, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        FilePath destination = new FilePath(getSourcesDir());
+        destination.mkdirs();
+
+        source = this.removeMaskFromPath(source, fileMask);
+        destination = new FilePath(new File(destination.getRemote(), source.getBaseName()));
+        destination.symlinkTo(source.getRemote(), listener);
+
+        return new AbstractMap.SimpleEntry<FilePath, FilePath>(source, destination);
+    }
+
+    protected FilePath removeMaskFromPath(@Nonnull FilePath path, @Nonnull String fileMask) {
+        String[] fileMasks;
+        if (fileMask.contains(",")) {
+            fileMasks = fileMask.split(", ");
+        } else {
+            fileMasks = new String[] { fileMask };
+        }
+
+        for (String mask : fileMasks) {
+            FilePath deductedPath = new FilePath(new File(path.getRemote()));
+            if (mask.contains("*")) {
+                String suffix = mask.substring(mask.lastIndexOf("*") + 1);
+                String splitPattern = Pattern.quote("/");
+
+                if (path.getRemote().contains("\\")) {
+                    suffix = suffix.replace("/", "\\");
+                    splitPattern = Pattern.quote("\\");
+                }
+
+                final FilePath fpSuffix = new FilePath(new File(suffix));
+
+                // Suffix doesn't match this path
+                if (!path.getRemote().endsWith(fpSuffix.getRemote())) {
+                    continue;
+                }
+
+                final List<String> children = Arrays.stream(suffix.split(splitPattern))
+                        .filter(child -> !child.equals(""))
+                        .collect(Collectors.toList());
+
+                for (int i = 0; i < children.size(); i++) {
+                    deductedPath = deductedPath.getParent();
+                }
+            }
+
+            // We are going to assume that the first mask
+            if (!path.equals(deductedPath)) {
+                return deductedPath;
+            }
+        }
+
+        return path;
     }
 
     /**
@@ -96,8 +173,9 @@ public class JacocoReportDir {
      * @param excludes see {@link ExecutionFileLoader#setExcludes}
      * @return the configured {@code ExecutionFileLoader}
      * @throws IOException if any I/O error occurs
+     * @throws InterruptedException if thread is interrupted
      */
-    public ExecutionFileLoader parse(String[] includes, String... excludes) throws IOException {
+    public ExecutionFileLoader parse(String[] includes, String... excludes) throws IOException, InterruptedException {
         ExecutionFileLoader efl = new ExecutionFileLoader();
         for (File exec : getExecFiles()) {
             efl.addExecFile(new FilePath(exec));

--- a/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/JacocoPublisher/config.jelly
@@ -47,6 +47,10 @@
       </table>
     </f:entry>
 
+    <f:entry field="symbolicLinks">
+        <f:checkbox checked="${instance.selected}" title="Use symbolic links to class and source files in build job"/>
+    </f:entry>
+
     <!-- Allow the user to enable/disable copy of source files -->
     <f:entry field="skipCopyOfSrcFiles">
        <f:checkbox checked="${instance.selected}" title="Disable display of source files for coverage"/>

--- a/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
+++ b/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 public class ExecutionFileLoaderTest {
 
     @Test
-    public void test() throws IOException {
+    public void test() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
         loader.addExecFile(new FilePath(new File(".")));
         
@@ -45,7 +45,7 @@ public class ExecutionFileLoaderTest {
     }
     
     @Test
-    public void testLoadBundleCoverageNoIncludes() throws IOException {
+    public void testLoadBundleCoverageNoIncludes() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
         
         loader.setClassDir(new FilePath(new File("target/classes")));
@@ -55,7 +55,7 @@ public class ExecutionFileLoaderTest {
     }
     
     @Test
-    public void testLoadBundleCoverageNoIncludes2() throws IOException {
+    public void testLoadBundleCoverageNoIncludes2() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
         
         loader.setClassDir(new FilePath(new File("target/classes")));
@@ -68,7 +68,7 @@ public class ExecutionFileLoaderTest {
     }
 
     @Test
-    public void testLoadBundleCoverageNoIncludes3() throws IOException {
+    public void testLoadBundleCoverageNoIncludes3() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
         
         loader.setClassDir(new FilePath(new File("target/classes")));
@@ -83,7 +83,7 @@ public class ExecutionFileLoaderTest {
     }
 
     @Test
-    public void testLoadBundleCoverageWithIncludes() throws IOException {
+    public void testLoadBundleCoverageWithIncludes() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
         
         loader.setClassDir(new FilePath(new File("target/classes")));
@@ -95,7 +95,7 @@ public class ExecutionFileLoaderTest {
     }
     
     @Test
-    public void testLoadBundleWithExecFile() throws IOException {
+    public void testLoadBundleWithExecFile() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
         
         assertTrue("This test requires that a jacoco.exec file exists in the target-directory", 
@@ -112,7 +112,7 @@ public class ExecutionFileLoaderTest {
     }
 
     @Test
-    public void testLoadBundleWithMissingExecFile() throws IOException {
+    public void testLoadBundleWithMissingExecFile() throws IOException, InterruptedException {
         ExecutionFileLoader loader = new ExecutionFileLoader();
 
         assertTrue("This test requires that a jacoco.exec file exists in the target-directory",
@@ -131,7 +131,7 @@ public class ExecutionFileLoaderTest {
     }
 
     @Test
-    public void testLoadBundleWithoutClasses() throws IOException {
+    public void testLoadBundleWithoutClasses() throws IOException, InterruptedException {
         // Special Jenkins publisher case to handle empty classes dir
         ExecutionFileLoader loader = new ExecutionFileLoader();
         

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -80,7 +80,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
     @SuppressWarnings("deprecation")
 	@Test
 	public void testConstruct() {
-		JacocoPublisher publisher = new JacocoPublisher(null, null, null, null, null, false,
+		JacocoPublisher publisher = new JacocoPublisher(null, null, null, null, null, false, false,
 				null, null, null, null,
 				null, null, null, null,
 				null, null, null, null,
@@ -145,6 +145,9 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 
 		publisher.setMinimumMethodCoverage("minM");
 		assertEquals("minM", publisher.getMinimumMethodCoverage());
+
+		publisher.setSymbolicLinks(true);
+		assertEquals(true, publisher.getSymbolicLinks());
 
 		assertNotNull(publisher.toString());
 
@@ -297,14 +300,14 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		assertTrue(f4.renameTo(f6));
 		f5.deleteOnExit();
 		f6.deleteOnExit();
-		
+
 		/*
-		// Look for files in the entire workspace recursively without providing 
+		// Look for files in the entire workspace recursively without providing
 		// the includes parameter
 		FilePath[] reports = JacocoPublisher.locateCoverageReports(workspace, "**e/jacoco*.xml");
 		assertEquals(2 , reports.length);
 
-		// Generate a includes string and look for files 
+		// Generate a includes string and look for files
 		String includes = f1.getName() + "; " + f2.getName() + "; " + d1.getName();
 		reports = JacocoPublisher.locateCoverageReports(workspace, includes);
 		assertEquals(3, reports.length);
@@ -313,7 +316,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		FilePath local = workspace.child("coverage_localfolder");
 		JacocoPublisher.saveCoverageReports(local, reports);
 		assertEquals(3, local.list().size());
-		
+
 		local.deleteRecursive();
 		 */
 
@@ -500,7 +503,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		PowerMock.replay(taskListener, run, job);
 
 		// execute
-		JacocoPublisher publisher = new JacocoPublisher("**/**.exec", "**/classes", "**/src/main/java", "", "", false, "0", "0"
+		JacocoPublisher publisher = new JacocoPublisher("**/**.exec", "**/classes", "**/src/main/java", "", "", false, false, "0", "0"
 				, "0", "0", "0", "0", "0", "0"
 				, "0", "0", "0", "0", false,
 				"10.564", "5.65", "9.995", "11.4529", "9.346", "5.237", true);

--- a/src/test/java/hudson/plugins/jacoco/JacocoReportDirTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoReportDirTest.java
@@ -1,0 +1,76 @@
+package hudson.plugins.jacoco;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import hudson.FilePath;
+
+public class JacocoReportDirTest extends AbstractJacocoTestBase {
+
+    @Test
+    public void testRemoveMaskFromPath() throws Exception {
+        final JacocoReportDir reportDir = new JacocoReportDir(new File("/home/jacoco"));
+        final Class<? extends JacocoReportDir> clazz = reportDir.getClass();
+        final Method method = clazz.getDeclaredMethod("removeMaskFromPath", new Class[]{FilePath.class, String.class});
+
+        // Unix paths
+        assertEquals(new FilePath(new File("/home/jacoco/code/src/jacoco")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code/src/jacoco/src/main/java")),
+                        "**/src/main/java"));
+
+        assertEquals(new FilePath(new File("/home/jacoco/code/src/jacoco/src/main")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code/src/jacoco/src/main/java")),
+                        "**/src/*/java"));
+
+        assertEquals(new FilePath(new File("/home/jacoco/code/src/jacoco")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code/src/jacoco/src/main/java")),
+                        "**/classes, **/src/main/java"));
+
+        assertEquals(new FilePath(new File("/home/jacoco/code/src/jacoco/src/main")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code/src/jacoco/src/main/java")),
+                        "**/classes, **/src/*/java"));
+
+        // Windows paths
+        assertEquals(new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco")),
+                method.invoke(reportDir, new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco\\src\\main\\java")),
+                        "**/src/main/java"));
+
+        assertEquals(new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco\\src\\main")),
+                method.invoke(reportDir, new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco\\src\\main\\java")),
+                        "**/src/*/java"));
+
+        assertEquals(new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco")),
+                method.invoke(reportDir, new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco\\src\\main\\java")),
+                        "**/classes, **/src/main/java"));
+
+        assertEquals(new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco\\src\\main")),
+                method.invoke(reportDir, new FilePath(new File("C:\\Users\\jacoco\\code\\src\\jacoco\\src\\main\\java")),
+                        "**/classes, **/src/*/java"));
+
+        // No expansion
+        assertEquals(new FilePath(new File("/home/jacoco/code")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code")),
+                        ""));
+
+        assertEquals(new FilePath(new File("/home/jacoco/code")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code")),
+                        " , **/src"));
+
+        assertEquals(new FilePath(new File("/home/jacoco")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code")),
+                        " , **/code"));
+
+        assertEquals(new FilePath(new File("/home/jacoco/code")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code")),
+                        "*"));
+
+        // Not a valid pattern
+        assertEquals(new FilePath(new File("/home/jacoco/code")),
+                method.invoke(reportDir, new FilePath(new File("/home/jacoco/code")),
+                        "nopattern"));
+    }
+}


### PR DESCRIPTION
The use case is a big application (more than 1 Gb, less than 2 gb), which collects metrics
via jacoco-agent every night, to get statitics of functional test coverage.

When the source and classes is copied for each job, the disk space usage get quite big over time.

When it's only the metrics changing, and not the classes and source, it makes more sense to use
symbolic links for these in the job directory instead of a copy.