### PR TITLE
set coverage percentage scale 2

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/model/Coverage.java
+++ b/src/main/java/hudson/plugins/jacoco/model/Coverage.java
@@ -1,6 +1,7 @@
 package hudson.plugins.jacoco.model;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -57,8 +58,9 @@ final public class Coverage implements Serializable {
      * @see #getPercentageFloat()
      */
     @Exported
-    public int getPercentage() {
-        return Math.round(getPercentageFloat());
+    public BigDecimal getPercentage() {
+        BigDecimal bd = new BigDecimal(getPercentageFloat());
+        return bd.setScale(2, BigDecimal.ROUND_HALF_UP);
     }
 
     /**

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -2,6 +2,8 @@ package hudson.plugins.jacoco.report;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -196,7 +198,7 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 		.append("<td class='percentgraph'>")
 		.append("<div class='percentgraph' style='width:100px'>")
 		.append("<div class='redbar' style='width:")
-		.append(100 - ratio.getPercentage()).append("px'>")
+		.append(BigDecimal.valueOf(100).subtract(ratio.getPercentage()).setScale(0, RoundingMode.HALF_UP)).append("px'>")
 		.append("</div></div></td></tr><tr><td colspan='2'>")
 		.append("<span class='text'><b>M:</b> ").append(ratio.getMissed())
 		.append(" <b>C:</b> ").append(ratio.getCovered()).append("</span></td></tr></table>\n");

--- a/src/test/java/hudson/plugins/jacoco/CoverageTest.java
+++ b/src/test/java/hudson/plugins/jacoco/CoverageTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import hudson.plugins.jacoco.model.Coverage;
 
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 import static org.junit.Assert.*;
@@ -17,7 +18,7 @@ public class CoverageTest extends AbstractJacocoTestBase {
 	@Test
     public void testPercentageCalculation() throws Exception {
         Coverage c = new Coverage(1, 2);
-        assertEquals(67, c.getPercentage());
+        assertEquals(BigDecimal.valueOf(66.67), c.getPercentage());
     }
 
 	@Test
@@ -42,7 +43,7 @@ public class CoverageTest extends AbstractJacocoTestBase {
 	@Test
     public void testVacuousCoverage() throws Exception {
         final Coverage c = new Coverage(0, 0);
-        assertEquals(100, c.getPercentage());
+        assertEquals(BigDecimal.valueOf(100).setScale(2), c.getPercentage());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/jacoco/report/CoverageReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/CoverageReportTest.java
@@ -5,6 +5,7 @@ import hudson.plugins.jacoco.ExecutionFileLoader;
 import hudson.plugins.jacoco.JacocoBuildAction;
 import hudson.plugins.jacoco.JacocoHealthReportThresholds;
 
+import hudson.plugins.jacoco.model.Coverage;
 import hudson.util.StreamTaskListener;
 import org.junit.Test;
 
@@ -34,6 +35,18 @@ public class CoverageReportTest {
     public void testThresholds() throws Exception {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
         report.setThresholds(new JacocoHealthReportThresholds());
+    }
+
+    @Test
+    public void testPrintRationTable() {
+        CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
+
+        Coverage ratio = new Coverage(37, 73); // 67.36% covered. 33.64 missed.
+        StringBuilder buf = new StringBuilder();
+
+        report.printRatioTable(ratio, buf);
+        assertTrue("redbar pixel width must be integer.", buf.toString().contains("class='redbar' style='width:34px'"));
+
     }
 
     private JacocoBuildAction action = new JacocoBuildAction(null, null, StreamTaskListener.fromStdout(), null, null);


### PR DESCRIPTION
As a project getting bigger, integer percentage is not enough.
Sometimes we cover a lot more lines, it just increases only 0.1 percentage.
Because of this, it seems that we don't try hard to test our codes.

So I changed Coverage.getPercentage() to BigDecimal with 2 decimal point.

Thanks,
KwonNam.