### PR TITLE
JENKINS-49823 - Ignore non existing class directory

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -102,6 +102,9 @@ public class ExecutionFileLoader implements Serializable {
 	    private IBundleCoverage analyzeStructure() throws IOException {
 	    	
 			File classDirectory = new File(classDir.getRemote());
+			if (!classDirectory.exists()) {
+				return null;
+			}
 			final CoverageBuilder coverageBuilder = new CoverageBuilder();
 			final Analyzer analyzer = new Analyzer(executionDataStore,
 					coverageBuilder);

--- a/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
+++ b/src/test/java/hudson/plugins/jacoco/ExecutionFileLoaderTest.java
@@ -93,7 +93,15 @@ public class ExecutionFileLoaderTest {
         assertNotNull(coverage);
         assertEquals(0, coverage.getClassCounter().getCoveredCount());
     }
-    
+
+    @Test
+    public void testLoadBundleCoverageClassDirectoryNotExists() throws IOException {
+        ExecutionFileLoader loader = new ExecutionFileLoader();
+        loader.setClassDir(new FilePath(new File("NotExisting")));
+        IBundleCoverage coverage = loader.loadBundleCoverage();
+        assertNull(coverage);
+    }
+
     @Test
     public void testLoadBundleWithExecFile() throws IOException {
         ExecutionFileLoader loader = new ExecutionFileLoader();


### PR DESCRIPTION
When using a Jenkins pipeline for multiple projects, there might not always be a classes directory (e.g. on pom-only projects). This PR ignores non-existing class directories.