### PR TITLE
Upgrade dashboard-view plugin to 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,13 +215,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>dashboard-view</artifactId>
-            <version>2.9.11</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.sourceforge.nekohtml</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>2.12</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
It contains security fixes and doesn't depend on the maven-plugin anymore.

The NekoHTML exclusion can be removed as it was only in place because of the maven-plugin with all its dependencies.

For all details see https://github.com/jenkinsci/dashboard-view-plugin/releases.