### PR TITLE
Remove obsolete maven-enforcer ASM exclude

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,23 +507,6 @@ THE SOFTWARE.
                     <maskClasses>org.objectweb.asm.</maskClasses>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>display-info</id>
-                        <configuration>
-                            <rules>
-                                <enforceBytecodeVersion>
-                                    <excludes combine.children="append">
-                                        <exclude>org.ow2.asm:*</exclude>
-                                    </excludes>
-                                </enforceBytecodeVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -512,15 +512,10 @@ THE SOFTWARE.
                 <executions>
                     <execution>
                         <id>display-info</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>display-info</goal>
-                            <goal>enforce</goal>
-                        </goals>
                         <configuration>
                             <rules>
                                 <enforceBytecodeVersion>
-                                    <excludes>
+                                    <excludes combine.children="append">
                                         <exclude>org.ow2.asm:*</exclude>
                                     </excludes>
                                 </enforceBytecodeVersion>


### PR DESCRIPTION
It was originally introduced because the ASM jar files contain a _module-info.class_ which is targeted to Java 9. When using JDK 8 for building the enforcer therefore complained.

The current parent pom uses the newer extra-enforcer-rules 1.2 which ignores the _module-info.class_ in case a JDK < 9 is used.

For more details see
- https://github.com/mojohaus/extra-enforcer-rules/issues/33
- https://github.com/mojohaus/extra-enforcer-rules/issues/46