### PR TITLE
JENKINS-60356 - Provide a link to the jacoco XML report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,6 +507,37 @@ THE SOFTWARE.
                     <maskClasses>org.objectweb.asm.</maskClasses>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <executable>mvn</executable>
+                            <workingDirectory>${project.build.testOutputDirectory}/report/example</workingDirectory>
+                            <arguments>
+                                <argument>clean</argument>
+                                <argument>package</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/example/ExampleTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -20,7 +20,7 @@ import org.jacoco.core.data.ExecutionDataReader;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfoStore;
 import org.jacoco.maven.FileFilter;
-
+import org.jacoco.report.IReportVisitor;
 
 public class ExecutionFileLoader implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -141,11 +141,23 @@ public class ExecutionFileLoader implements Serializable {
 			return this.bundleCoverage;
 		}
 
+		public void read(IReportVisitor visitor, String name) throws IOException {
+			setName(name);
+			loadBundleCoverage();
+			visitor.visitInfo(sessionInfoStore.getInfos(), executionDataStore.getContents());
+			visitor.visitBundle(bundleCoverage, null);
+			visitor.visitEnd();
+		}
+
 		public void setIncludes(String... includes) {
 			this.includes = includes;
 		}
 
 		public void setExcludes(String... excludes) {
 			this.excludes = excludes;
+		}
+
+		public boolean isEmpty() {
+			return execFiles.isEmpty();
 		}
 }

--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -218,6 +218,10 @@ public final class JacocoBuildAction extends CoverageObject<JacocoBuildAction> i
         return new JacocoReportDir(owner.getRootDir());
     }
 
+	public ExecutionFileLoader getExecutionFileLoader() throws IOException {
+		return getJacocoReport().parse(inclusions, exclusions);
+	}
+
 	/**
 	 * Obtains the detailed {@link CoverageReport} instance.
 	 * @return the report, or null if these was a problem

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -19,6 +19,7 @@ import org.jacoco.core.analysis.IMethodCoverage;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.data.ExecutionDataWriter;
 import org.jacoco.core.tools.ExecFileLoader;
+import org.jacoco.report.xml.XMLFormatter;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -250,6 +251,21 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
         }
     }
 
+    @WebMethod(name="jacoco.xml")
+    public HttpResponse doJacocoXml() throws IOException {
+        ExecutionFileLoader loader = action.getExecutionFileLoader();
+        if (loader.isEmpty()) {
+            return HttpResponses.error(404, "No jacoco.exec file recorded");
+        }
+        return new HttpResponse() {
+            @Override
+            public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
+                rsp.setContentType("text/xml");
+                rsp.setHeader("Content-Disposition", "attachment; filename=\"jacoco.xml\"");
+                loader.read(new XMLFormatter().createVisitor(rsp.getOutputStream()), getName());
+            }
+        };
+    }
 
 	public void setThresholds(JacocoHealthReportThresholds healthReports) {
 		this.healthReports = healthReports;

--- a/src/main/resources/hudson/plugins/jacoco/report/CoverageReport/index.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/report/CoverageReport/index.jelly
@@ -4,11 +4,14 @@
     <st:include it="${it.build}" page="sidepanel.jelly" />
     <l:main-panel>
       <h2>${%JaCoCo Coverage Report}</h2>
-      <div>
+      <table><tr>
+        <td rowspan="2">
         <img src="${imagesURL}/24x24/save.png" />
-
+        </td><td>
         <a href="jacoco.exec">Download <tt>jacoco.exec</tt> binary coverage file</a>
-      </div>
+        </td></tr><tr><td>
+        <a href="jacoco.xml">Download <tt>jacoco.xml</tt> coverage report</a>
+      </td></tr></table>
 
       <e:floatingTrendGraph/>
 

--- a/src/test/java/hudson/plugins/jacoco/report/CoverageReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/CoverageReportTest.java
@@ -1,15 +1,30 @@
 package hudson.plugins.jacoco.report;
 
+import static org.easymock.EasyMock.*;
+import static org.easymock.MockType.NICE;
 import static org.junit.Assert.*;
+
+import hudson.model.Run;
 import hudson.plugins.jacoco.ExecutionFileLoader;
 import hudson.plugins.jacoco.JacocoBuildAction;
 import hudson.plugins.jacoco.JacocoHealthReportThresholds;
 
 import hudson.util.StreamTaskListener;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 import org.junit.Test;
+import org.kohsuke.stapler.StaplerResponse;
 
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 public class CoverageReportTest {
+    private static final String EXAMPLE_ROOT_DIR = "/report/example";
+    private static final String EXAMPLE_XML_FILE = "/report/example/target/jacoco/jacoco.xml";
+
     @Test
     public void testGetBuild() throws Exception {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
@@ -31,10 +46,52 @@ public class CoverageReportTest {
     }
 
     @Test
+    public void testDoJacocoXml() throws Exception {
+        OutputStream output = new ByteArrayOutputStream();
+        StaplerResponse response = mock(NICE, StaplerResponse.class);
+        expect(response.getOutputStream()).andReturn(new ServletOutputStream() {
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener writeListener) {
+            }
+
+            @Override
+            public void write(int b) throws IOException {
+                output.write(b);
+            }
+        });
+        response.setHeader("Content-Disposition", "attachment; filename=\"jacoco.xml\"");
+
+        File rootDir = Paths.get(CoverageReportTest.class.getResource(EXAMPLE_ROOT_DIR).toURI()).toFile();
+        Run<?, ?> owner = mock(NICE, Run.class);
+        expect(owner.getRootDir()).andReturn(rootDir);
+
+        File xmlFile = Paths.get(CoverageReportTest.class.getResource(EXAMPLE_XML_FILE).toURI()).toFile();
+        String expected = FileUtils.readFileToString(xmlFile, StandardCharsets.UTF_8);
+
+        replay(owner, response);
+        action.onLoad(owner);
+        CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
+        report.setName("jacoco-example");
+        report.doJacocoXml().generateResponse(null, response, null);
+
+        assertEquals(expected, output.toString());
+    }
+
+    @Test
     public void testThresholds() throws Exception {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
         report.setThresholds(new JacocoHealthReportThresholds());
     }
 
-    private JacocoBuildAction action = new JacocoBuildAction(null, null, StreamTaskListener.fromStdout(), null, null);
+    @Before
+    public void setUp() {
+        action = new JacocoBuildAction(null, null, StreamTaskListener.fromStdout(), null, null);
+    }
+
+    private JacocoBuildAction action;
 }

--- a/src/test/resources/report/example/jacoco/sources/com/example/Example.java
+++ b/src/test/resources/report/example/jacoco/sources/com/example/Example.java
@@ -1,0 +1,8 @@
+package com.example;
+
+public class Example {
+
+    public String getMessage(String name) {
+        return "Hello, " + name;
+    }
+}

--- a/src/test/resources/report/example/jacoco/tests/com/example/ExampleTest.java
+++ b/src/test/resources/report/example/jacoco/tests/com/example/ExampleTest.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ExampleTest {
+
+    @Test
+    public void test() {
+        Example example = new Example();
+
+        String actual = example.getMessage("World");
+
+        assertEquals("Hello, World", actual);
+    }
+}

--- a/src/test/resources/report/example/pom.xml
+++ b/src/test/resources/report/example/pom.xml
@@ -6,6 +6,12 @@
     <version>1.0</version>
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -23,7 +29,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>
@@ -42,7 +48,7 @@
                         <phase>package</phase>
                         <configuration>
                             <dataFile>jacoco/execFiles/exec0/jacoco.exec</dataFile>
-                            <outputDirectory>${build.directory}/jacoco</outputDirectory>
+                            <outputDirectory>${project.build.directory}/jacoco</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/test/resources/report/example/pom.xml
+++ b/src/test/resources/report/example/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>jacoco-example</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>jacoco/sources</sourceDirectory>
+        <outputDirectory>jacoco/classes</outputDirectory>
+        <testSourceDirectory>jacoco/tests</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>jacoco/execFiles/exec0/jacoco.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <dataFile>jacoco/execFiles/exec0/jacoco.exec</dataFile>
+                            <outputDirectory>${build.directory}/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Provide an additional link in the coverage results page to download the aggregated `jacoco.xml` file.

See the full description in [JENKINS-60356](https://issues.jenkins-ci.org/browse/JENKINS-60356).