### PR TITLE
Fix scm url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ THE SOFTWARE.
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/jacoco-plugin.git</connection>
+        <connection>scm:git:ssh://git@github.com/jenkinsci/jacoco-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/jacoco-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/jacoco-plugin</url>
         <tag>HEAD</tag>


### PR DESCRIPTION
Trying to execute the PCT for this plugin, I get an error when the git clone command is executed. The `connection` value in `scm`pom section is not updated.

@centic9 

It would be nice to have it fixed and released so we could launch the PCT for the whole set of plugins we're using.