### PR TITLE
Ignore test dependant on the platform

### DIFF
--- a/src/test/java/hudson/plugins/jacoco/model/CoverageObjectGraphTest.java
+++ b/src/test/java/hudson/plugins/jacoco/model/CoverageObjectGraphTest.java
@@ -12,6 +12,7 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.awt.Color;
@@ -27,6 +28,7 @@ import java.util.Locale;
 
 import static org.junit.Assert.assertArrayEquals;
 
+@Ignore("Flaky tests. Dependant on the platform")
 public class CoverageObjectGraphTest extends AbstractJacocoTestBase {
 	private static final int WIDTH = 500;
 	private static final int HEIGHT = 200;


### PR DESCRIPTION
`CoverageObjectGraphTest` depends on the platform (JVM), so it's flaky:

- It fails for java 8 and java 11 when the JVM is OpenJDK
- It fails for java 8 when the JVM is AdoptJDK (ci.jenkins.io)
- It passes for java 11 when the JVM is AdoptJDK
- It passes for Oracle JDK

The test should be re-designed so it becomes platform-independent but for the moment my proposal is to ignore it

Note: it's nothing to do with master. I can reproduce the flakiness with past releases.