### PR TITLE
[JENKINS-62715] Allow to run tests with custom arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@ THE SOFTWARE.
         <jenkins.version>2.150.3</jenkins.version>
         <maven.version>3.5.2</maven.version>
         <powermock.version>2.0.7</powermock.version>
+        <!-- Do not fail if tests are run without argLine -->
+        <argLine></argLine>
     </properties>
 
     <licenses>
@@ -425,6 +427,14 @@ THE SOFTWARE.
                                 </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+                <!-- Allow test execution when specifying surefire argLine via CLI -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>@{argLine} ${argLine}</argLine>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
See [JENKINS-62715](https://issues.jenkins-ci.org/browse/JENKINS-62715) 

Previously any usage of `argLine`surefire property would result in the jacoco agent not being used by tests