### PR TITLE
[JENKINS-58184] Resolved the issue where even coverage increase was failing the build

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -777,10 +777,9 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
                 + ", complexity: " + deltaCoverageResultSummary.getComplexityCoverage());
 
         /**
-         * If the coverage for a particular parameter has increased we are not checking it against the configured thresholds.
-         * Only if the coverage for a particular parameter has decreased we check the value against the configured thresholds.
-         * In case all the parameter coverage has increased then thresholds will not be checked at all.
-         * [JENKINS-58184] - This fix will ensure that checks will never fail in case the coverage is increasing beyond threshold for any parameter
+         * Coverage thresholds will not be checked for any parameter for which the coverage has increased.
+         * Only if the coverage for a particular parameter has decreased, we will check the the configured threshold for that parameter.
+         * [JENKINS-58184] - This fix ensures that build will never fail in case coverage reduction is within the threshold limits.
          */
         if((deltaCoverageResultSummary.getInstructionCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getInstructionCoverage()) <= deltaHealthReport.getDeltaInstruction()) &&
                 ( deltaCoverageResultSummary.getBranchCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getBranchCoverage()) <= deltaHealthReport.getDeltaBranch()) &&

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -776,14 +776,18 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
                 + ", instruction: " + deltaCoverageResultSummary.getInstructionCoverage()
                 + ", complexity: " + deltaCoverageResultSummary.getComplexityCoverage());
 
-        if(Math.abs(deltaCoverageResultSummary.getInstructionCoverage()) <= deltaHealthReport.getDeltaInstruction() &&
-                Math.abs(deltaCoverageResultSummary.getBranchCoverage()) <= deltaHealthReport.getDeltaBranch() &&
-                Math.abs(deltaCoverageResultSummary.getComplexityCoverage()) <= deltaHealthReport.getDeltaComplexity() &&
-                Math.abs(deltaCoverageResultSummary.getLineCoverage()) <= deltaHealthReport.getDeltaLine() &&
-                Math.abs(deltaCoverageResultSummary.getMethodCoverage()) <= deltaHealthReport.getDeltaMethod() &&
-                Math.abs(deltaCoverageResultSummary.getClassCoverage()) <= deltaHealthReport.getDeltaClass())
-            return Result.SUCCESS;
-        else if(deltaCoverageResultSummary.isCoverageBetterThanPrevious())
+        /**
+         * If the coverage for a particular parameter has increased we are not checking it against the configured thresholds.
+         * If the coverage for a particular parameter is less than zero we check the value against the configured threshold
+         * In case all the parameter coverage has increased then thresholds will not be checked.
+         * [JENKINS-58184] - This fix will ensure that check will never fail in case the coverage is increasing beyond threshold
+         */
+        if((deltaCoverageResultSummary.getInstructionCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getInstructionCoverage()) <= deltaHealthReport.getDeltaInstruction()) &&
+                ( deltaCoverageResultSummary.getBranchCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getBranchCoverage()) <= deltaHealthReport.getDeltaBranch()) &&
+                ( deltaCoverageResultSummary.getComplexityCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getComplexityCoverage()) <= deltaHealthReport.getDeltaComplexity()) &&
+                ( deltaCoverageResultSummary.getLineCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getLineCoverage()) <= deltaHealthReport.getDeltaLine()) &&
+                ( deltaCoverageResultSummary.getMethodCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getMethodCoverage()) <= deltaHealthReport.getDeltaMethod()) &&
+                ( deltaCoverageResultSummary.getClassCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getClassCoverage()) <= deltaHealthReport.getDeltaClass()))
             return Result.SUCCESS;
         else
             return Result.FAILURE;

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -778,9 +778,9 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
 
         /**
          * If the coverage for a particular parameter has increased we are not checking it against the configured thresholds.
-         * If the coverage for a particular parameter is less than zero we check the value against the configured threshold
-         * In case all the parameter coverage has increased then thresholds will not be checked.
-         * [JENKINS-58184] - This fix will ensure that check will never fail in case the coverage is increasing beyond threshold
+         * Only if the coverage for a particular parameter has decreased we check the value against the configured thresholds.
+         * In case all the parameter coverage has increased then thresholds will not be checked at all.
+         * [JENKINS-58184] - This fix will ensure that checks will never fail in case the coverage is increasing beyond threshold for any parameter
          */
         if((deltaCoverageResultSummary.getInstructionCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getInstructionCoverage()) <= deltaHealthReport.getDeltaInstruction()) &&
                 ( deltaCoverageResultSummary.getBranchCoverage() > 0 || Math.abs(deltaCoverageResultSummary.getBranchCoverage()) <= deltaHealthReport.getDeltaBranch()) &&

--- a/src/main/java/hudson/plugins/jacoco/portlet/bean/JacocoDeltaCoverageResultSummary.java
+++ b/src/main/java/hudson/plugins/jacoco/portlet/bean/JacocoDeltaCoverageResultSummary.java
@@ -25,8 +25,6 @@ public class JacocoDeltaCoverageResultSummary {
 
     private float classCoverage;
 
-    private boolean coverageBetterThanPrevious=false;
-
     public JacocoDeltaCoverageResultSummary() {
     }
 
@@ -43,16 +41,6 @@ public class JacocoDeltaCoverageResultSummary {
         jacocoDeltaCoverageResultSummary.lineCoverage = currentBuildCoverage.getLineCoverage() - lastBuildCoverage.getLineCoverage();
         jacocoDeltaCoverageResultSummary.methodCoverage = currentBuildCoverage.getMethodCoverage() - lastBuildCoverage.getMethodCoverage();
         jacocoDeltaCoverageResultSummary.classCoverage = currentBuildCoverage.getClassCoverage() - lastBuildCoverage.getClassCoverage();
-
-        if(currentBuildCoverage.getInstructionCoverage() >= lastBuildCoverage.getInstructionCoverage()
-                && currentBuildCoverage.getBranchCoverage() >= lastBuildCoverage.getBranchCoverage()
-                && currentBuildCoverage.getComplexityScore() >= lastBuildCoverage.getComplexityScore()
-                && currentBuildCoverage.getLineCoverage() >= lastBuildCoverage.getLineCoverage()
-                && currentBuildCoverage.getMethodCoverage() >= lastBuildCoverage.getMethodCoverage()
-                && currentBuildCoverage.getClassCoverage() >= lastBuildCoverage.getClassCoverage())
-            // Since delta coverage is the absolute difference by definition,
-            // use this flag to mark if the current coverage is bigger than the coverage of last successful build
-            jacocoDeltaCoverageResultSummary.coverageBetterThanPrevious = true;
 
         return jacocoDeltaCoverageResultSummary;
     }
@@ -81,10 +69,6 @@ public class JacocoDeltaCoverageResultSummary {
         return classCoverage;
     }
 
-    public boolean isCoverageBetterThanPrevious() {
-        return coverageBetterThanPrevious;
-    }
-
     public void setInstructionCoverage(float instructionCoverage) {
         this.instructionCoverage = instructionCoverage;
     }
@@ -109,10 +93,6 @@ public class JacocoDeltaCoverageResultSummary {
         this.classCoverage = classCoverage;
     }
 
-    public void setCoverageBetterThanPrevious(boolean coverageBetterThanPrevious) {
-        this.coverageBetterThanPrevious = coverageBetterThanPrevious;
-    }
-
     @Override
     public String toString() {
         return "JacocoDeltaCoverageResultSummary [" +
@@ -122,7 +102,6 @@ public class JacocoDeltaCoverageResultSummary {
                 ", lineCoverage=" + lineCoverage +
                 ", methodCoverage=" + methodCoverage +
                 ", classCoverage=" + classCoverage +
-                ", coverageBetterThanPrevious=" + coverageBetterThanPrevious +
                 ']';
     }
 }

--- a/src/test/java/hudson/plugins/jacoco/BuildOverBuildTest.java
+++ b/src/test/java/hudson/plugins/jacoco/BuildOverBuildTest.java
@@ -56,8 +56,8 @@ public class BuildOverBuildTest {
     }
 
     /**
-     * [JENKINS-58184] - This test verifies that we are not ignoring positive coverage changes while checking against the thresholds.
-     * Instruction Coverage has gone down but is still within the configured threshold limit
+     * [JENKINS-58184] - This test verifies that we are now ignoring positive coverage changes while checking against the thresholds.
+     * Instruction Coverage has gone down but is still within the configured threshold limit.
      * Method and line coverage has increased and are way above thresholds.
      * The check passes the build as no decrease is more than the configured threshold
      */
@@ -81,7 +81,6 @@ public class BuildOverBuildTest {
     }
 
     // Test if the build with delta coverage < delta threshold will pass
-    // and build with delta coverage > delta threshold but overall coverage better than last successful will pass
     @Test
     public void checkBuildOverBuildSuccessTest(){
 
@@ -107,9 +106,9 @@ public class BuildOverBuildTest {
     }
 
     /**
-     * [JENKINS-58184] - This test verify that we are still respecting the threshold and are failing the build
-     * in case the drop in coverage is more than the configured threshold for any parameter
-     * Drop in complexity coverage is more than the configured limit of 2.3434
+     * [JENKINS-58184] - This test verify that we are still respecting the thresholds and are failing the build
+     *                  in case the drop in coverage is more than the configured threshold for any parameter
+     * Drop in complexity coverage is more than the configured limit of 2.3434 and so the build fails
      */
     @Test
     public void shouldFailIfNegativeMetricIsAboveThresholdAndOtherMetricesArePositive(){

--- a/src/test/java/hudson/plugins/jacoco/BuildOverBuildTest.java
+++ b/src/test/java/hudson/plugins/jacoco/BuildOverBuildTest.java
@@ -36,13 +36,12 @@ public class BuildOverBuildTest {
     @Before
     public void setUp(){
         jacocoDeltaCoverageResultSummary_1 = new JacocoDeltaCoverageResultSummary();
-        jacocoDeltaCoverageResultSummary_1.setInstructionCoverage(12.234f);
+        jacocoDeltaCoverageResultSummary_1.setInstructionCoverage(-9.234f);
         jacocoDeltaCoverageResultSummary_1.setClassCoverage(0.5523f);
         jacocoDeltaCoverageResultSummary_1.setMethodCoverage(11.8921f);
         jacocoDeltaCoverageResultSummary_1.setLineCoverage(21.523f);
         jacocoDeltaCoverageResultSummary_1.setBranchCoverage(0f);
         jacocoDeltaCoverageResultSummary_1.setComplexityCoverage(1.34f);
-        jacocoDeltaCoverageResultSummary_1.setCoverageBetterThanPrevious(false);
 
         jacocoDeltaCoverageResultSummary_2 = new JacocoDeltaCoverageResultSummary();
         jacocoDeltaCoverageResultSummary_2.setInstructionCoverage(7.54f);
@@ -51,15 +50,19 @@ public class BuildOverBuildTest {
         jacocoDeltaCoverageResultSummary_2.setLineCoverage(7.8921f);
         jacocoDeltaCoverageResultSummary_2.setBranchCoverage(0f);
         jacocoDeltaCoverageResultSummary_2.setComplexityCoverage(1.678f);
-        jacocoDeltaCoverageResultSummary_2.setCoverageBetterThanPrevious(true);
 
         deltaHealthThresholds = new JacocoHealthReportDeltaThresholds("10.556", "0", "2.3434", "9.11457", "8.2525", "1.5556");
         //healthThresholds = new JacocoHealthReportThresholds(88, 100, 85, 100, 75, 90, 100, 100, 83, 95, 86, 92);
     }
 
-    // Test if the build with delta coverage > delta threshold and overall coverage lesser than last successful build will fail
+    /**
+     * [JENKINS-58184] - This test verifies that we are not ignoring positive coverage changes while checking against the thresholds.
+     * Instruction Coverage has gone down but is still within the configured threshold limit
+     * Method and line coverage has increased and are way above thresholds.
+     * The check passes the build as no decrease is more than the configured threshold
+     */
     @Test
-    public void checkBuildOverBuildFailureTest(){
+    public void shouldPassIfNegativeMetricIsWithinThresholdAndOtherMetricesArePositiveAndAboveThreshold(){
 
         PowerMock.mockStatic(JacocoDeltaCoverageResultSummary.class);
         //noinspection ConstantConditions
@@ -73,7 +76,7 @@ public class BuildOverBuildTest {
 
         PowerMock.verify(JacocoDeltaCoverageResultSummary.class);
 
-        Assert.assertEquals("Delta coverage is greater than delta health threshold values", Result.FAILURE, result);
+        Assert.assertEquals("Delta coverage drop is lesser than delta health threshold values", Result.SUCCESS, result);
 
     }
 
@@ -85,7 +88,6 @@ public class BuildOverBuildTest {
         PowerMock.mockStatic(JacocoDeltaCoverageResultSummary.class);
         //noinspection ConstantConditions
         expect(JacocoDeltaCoverageResultSummary.build(anyObject(Run.class))).andReturn(jacocoDeltaCoverageResultSummary_2);
-        jacocoDeltaCoverageResultSummary_1.setCoverageBetterThanPrevious(true);
         //noinspection ConstantConditions
         expect(JacocoDeltaCoverageResultSummary.build(anyObject(Run.class))).andReturn(jacocoDeltaCoverageResultSummary_1);
 
@@ -101,6 +103,36 @@ public class BuildOverBuildTest {
         Assert.assertEquals("Delta coverage is greater than delta health threshold values but overall coverage is better than last successful build's coverage", Result.SUCCESS, result);
 
         PowerMock.verify(JacocoDeltaCoverageResultSummary.class);
+
+    }
+
+    /**
+     * [JENKINS-58184] - This test verify that we are still respecting the threshold and are failing the build
+     * in case the drop in coverage is more than the configured threshold for any parameter
+     * Drop in complexity coverage is more than the configured limit of 2.3434
+     */
+    @Test
+    public void shouldFailIfNegativeMetricIsAboveThresholdAndOtherMetricesArePositive(){
+        JacocoDeltaCoverageResultSummary jacocoDeltaCoverageResultSummary = new JacocoDeltaCoverageResultSummary();
+        jacocoDeltaCoverageResultSummary.setInstructionCoverage(7.54f);
+        jacocoDeltaCoverageResultSummary.setClassCoverage(0.439f);
+        jacocoDeltaCoverageResultSummary.setMethodCoverage(5.340f);
+        jacocoDeltaCoverageResultSummary.setLineCoverage(7.8921f);
+        jacocoDeltaCoverageResultSummary.setBranchCoverage(0f);
+        jacocoDeltaCoverageResultSummary.setComplexityCoverage(-2.678f);
+
+        PowerMock.mockStatic(JacocoDeltaCoverageResultSummary.class);
+        //noinspection ConstantConditions
+        expect(JacocoDeltaCoverageResultSummary.build(anyObject(Run.class))).andReturn(jacocoDeltaCoverageResultSummary);
+
+        PowerMock.replay(JacocoDeltaCoverageResultSummary.class);
+
+        JacocoPublisher jacocoPublisher = new JacocoPublisher();
+        jacocoPublisher.deltaHealthReport = deltaHealthThresholds;
+        Result result = jacocoPublisher.checkBuildOverBuildResult(run, logger);
+
+        PowerMock.verify(JacocoDeltaCoverageResultSummary.class);
+        Assert.assertEquals("Delta coverage drop is greater than delta health threshold values", Result.FAILURE, result);
 
     }
 }

--- a/src/test/java/hudson/plugins/jacoco/BuildOverBuildTest.java
+++ b/src/test/java/hudson/plugins/jacoco/BuildOverBuildTest.java
@@ -56,9 +56,9 @@ public class BuildOverBuildTest {
     }
 
     /**
-     * [JENKINS-58184] - This test verifies that we are now ignoring positive coverage changes while checking against the thresholds.
-     * Instruction Coverage has gone down but is still within the configured threshold limit.
-     * Method and line coverage has increased and are way above thresholds.
+     * [JENKINS-58184] - This test verifies that we are ignoring coverage increase while checking against the thresholds.
+     * In this test data, Instruction Coverage has gone down but it is still within the configured threshold limit.
+     *                  Method and line coverage has increased and are way above thresholds.
      * The check passes the build as no decrease is more than the configured threshold
      */
     @Test
@@ -106,9 +106,9 @@ public class BuildOverBuildTest {
     }
 
     /**
-     * [JENKINS-58184] - This test verify that we are still respecting the thresholds and are failing the build
+     * [JENKINS-58184] - This test verifies that we are still respecting the thresholds and are failing the build
      *                  in case the drop in coverage is more than the configured threshold for any parameter
-     * Drop in complexity coverage is more than the configured limit of 2.3434 and so the build fails
+     * In this test data, drop in complexity coverage is more than the configured limit of 2.3434 and so the build fails
      */
     @Test
     public void shouldFailIfNegativeMetricIsAboveThresholdAndOtherMetricesArePositive(){

--- a/src/test/java/hudson/plugins/jacoco/portlet/JacocoDeltaCoverageResultSummaryTest.java
+++ b/src/test/java/hudson/plugins/jacoco/portlet/JacocoDeltaCoverageResultSummaryTest.java
@@ -85,7 +85,6 @@ public class JacocoDeltaCoverageResultSummaryTest {
                 currentBuildwithMoreCoverage.getMethodCoverage() - lastSuccessfulBuildCoverage.getMethodCoverage(), deltaCoverageSummary.getMethodCoverage(), 0.00001);
         assertEquals("Absolute difference in class coverage",
                 currentBuildwithMoreCoverage.getClassCoverage() - lastSuccessfulBuildCoverage.getClassCoverage(), deltaCoverageSummary.getClassCoverage(), 0.00001);
-        assertTrue(deltaCoverageSummary.isCoverageBetterThanPrevious());
     }
 
     // Test delta coverage summary when current build has worse coverage than previous successful build
@@ -118,6 +117,5 @@ public class JacocoDeltaCoverageResultSummaryTest {
                 currentBuildWithLesserCoverage.getMethodCoverage() - lastSuccessfulBuildCoverage.getMethodCoverage(), deltaCoverageSummary.getMethodCoverage(), 0.00001);
         assertEquals("Absolute difference in class coverage",
                 currentBuildWithLesserCoverage.getClassCoverage() - lastSuccessfulBuildCoverage.getClassCoverage(), deltaCoverageSummary.getClassCoverage(), 0.00001);
-        assertFalse(deltaCoverageSummary.isCoverageBetterThanPrevious());
     }
 }


### PR DESCRIPTION
Old Behaviour:
For example, Coverage for one parameter has increased but for other it has decreased. The increase in coverage is more than the threshold but the decrease is still under the configured threshold. In this case the build fails.

Updated Behaviour:
Build will only fail in case the drop in coverage is more than the configured threshold. It will simply ignore the coverage increase for any parameter.