### PR TITLE
updated the overall coverage reporting also as a float percentage

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -684,12 +684,12 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
             logger.println("[JaCoCo plugin] Could not parse coverage results. Setting Build to failure.");
             run.setResult(Result.FAILURE);
         } else {
-            logger.println("[JaCoCo plugin] Overall coverage: class: " + result.getClassCoverage().getPercentage()
-                    + ", method: " + result.getMethodCoverage().getPercentage()
-                    + ", line: " + result.getLineCoverage().getPercentage()
-                    + ", branch: " + result.getBranchCoverage().getPercentage()
-                    + ", instruction: " + result.getInstructionCoverage().getPercentage()
-                    + ", complexity: " + result.getComplexityScore().getPercentage());
+            logger.println("[JaCoCo plugin] Overall coverage: class: " + result.getClassCoverage().getPercentageFloat()
+                    + ", method: " + result.getMethodCoverage().getPercentageFloat()
+                    + ", line: " + result.getLineCoverage().getPercentageFloat()
+                    + ", branch: " + result.getBranchCoverage().getPercentageFloat()
+                    + ", instruction: " + result.getInstructionCoverage().getPercentageFloat()
+                    + ", complexity: " + result.getComplexityScore().getPercentageFloat());
             result.setThresholds(healthReports);
 
             // Calculate final result of the current build according to the state of two flags: changeBuildStatus and buildOverBuild


### PR DESCRIPTION
Hi All,

I was analysing logs as they are generated by the JaCoCo plugin. In the logs we report the delta coverage as a float which is fine as it gives us the exact change in the coverage. 
However we are reporting the overall coverage as a whole number percentage. This seems inconsistent and also for bigger projects where a whole number increase or decrease will take considerable effort this reporting hides some valuable information.

For this reason I have switched the overall coverage reporting also to a float percentage so as to keep things consistent. Also people in large projects can use this overall coverage reported in the logs to get exact coverage details. 