### PR TITLE
Bump jacoco version to 0.8.7. This allows using Kotlin 1.5 with Jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
     <properties>
         <java.level>8</java.level>
-        <jacoco.version>0.8.6</jacoco.version>
+        <jacoco.version>0.8.7</jacoco.version>
         <jenkins.version>2.164.3</jenkins.version>
         <maven.version>3.5.2</maven.version>
         <powermock.version>2.0.7</powermock.version>


### PR DESCRIPTION
Bumping Jacoco to 0.8.7 will allow the use of Kotlin 1.5:
See https://github.com/jacoco/jacoco/issues/1155

ISSUE:
https://issues.jenkins.io/browse/JENKINS-65562
<!-- Please describe your pull request here. -->

- [ X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ X ] Ensure that the pull request title represents the desired changelog entry
- [ X ] Please describe what you did
- [ X ] Link to relevant issues in GitHub or Jira
- [  ] Link to relevant pull requests, esp. upstream and downstream changes
- [  ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
