### PR TITLE
[JENKINS-65757] only use pluginFirst classloader when you have no other option (and never for guice!)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,13 +254,6 @@ THE SOFTWARE.
             <artifactId>plexus-utils</artifactId>
             <version>3.2.1</version>
         </dependency>
-        <!-- Somehow we need org.w3c.dom.ElementTraversal, but do not get it from any of the dependencies
-        do not update to 2.x as it will not contain the class any more! -->
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -262,11 +262,6 @@ THE SOFTWARE.
             <version>1.4.01</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.13</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -284,27 +284,6 @@ THE SOFTWARE.
 
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <phase>insert-test</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.objectweb.asm</pattern>
-                                    <shadedPattern>org.kohsuke.asm3</shadedPattern>
-                                </relocation>
-                            </relocations>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -211,16 +211,6 @@ THE SOFTWARE.
                 <artifactId>maven-plugin</artifactId>
                 <version>3.7</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>4.2.1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>30.1-jre</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -257,51 +247,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco.version}</version>
-            <!-- Exclude a few unused transitive dependencies of things that are not needed here to avoid clashes with other plugins -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.maven.doxia</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.sonatype.plexus</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-settings</artifactId>
-            <version>${maven.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.18</version>
+        <version>4.19</version>
     </parent>
 
     <artifactId>jacoco</artifactId>
@@ -44,8 +44,8 @@ THE SOFTWARE.
         <jacoco.version>0.8.7</jacoco.version>
         <!-- see https://www.jenkins.io/changelog-stable/ for changelog of the LTS releases -->
         <jenkins.version>2.263.4</jenkins.version>
-        <maven.version>3.8.1</maven.version>
-        <powermock.version>2.0.7</powermock.version>
+        <!--  until the plugin-pom picks up a newer version -->
+        <jenkins-test-harness.version>1589.vc23fca066d5c</jenkins-test-harness.version>
         <!-- Do not fail if tests are run without argLine -->
         <argLine />
     </properties>
@@ -113,107 +113,6 @@ THE SOFTWARE.
         </repository>
     </distributionManagement>
 
-    <!-- enforce versions of transitive dependencies to match RequireUpperBoundDeps rule -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.8.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant</artifactId>
-                <version>1.10.9</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>4.5.13</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-core</artifactId>
-                <version>${maven.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-embedder</artifactId>
-                <version>${maven.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-repository-metadata</artifactId>
-                <version>${maven.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.reporting</groupId>
-                <artifactId>maven-reporting-api</artifactId>
-                <version>3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-sink-api</artifactId>
-                <version>1.9.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-site-renderer</artifactId>
-                <version>1.7.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.reporting</groupId>
-                <artifactId>maven-reporting-impl</artifactId>
-                <version>3.0.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.shared</groupId>
-                <artifactId>maven-shared-utils</artifactId>
-                <version>3.2.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-velocity</artifactId>
-                <version>1.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-aether-provider</artifactId>
-                <version>3.3.9</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-classworlds</artifactId>
-                <version>2.6.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-component-annotations</artifactId>
-                <version>2.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-container-default</artifactId>
-                <version>1.7.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-interpolation</artifactId>
-                <version>1.24</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>maven-plugin</artifactId>
-                <version>3.7</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -235,7 +134,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -463,7 +361,6 @@ THE SOFTWARE.
                     </execution>
                 </executions>
                 <configuration>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
                     <maskClasses>org.objectweb.asm.</maskClasses>
                 </configuration>
             </plugin>

--- a/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
+++ b/src/main/java/hudson/plugins/jacoco/ExecutionFileLoader.java
@@ -19,7 +19,6 @@ import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.data.ExecutionDataReader;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfoStore;
-import org.jacoco.maven.FileFilter;
 
 
 public class ExecutionFileLoader implements Serializable {
@@ -122,9 +121,8 @@ public class ExecutionFileLoader implements Serializable {
 				excludes = ITEM_ZERO;
 			}
 
-			final FileFilter fileFilter = new FileFilter(Arrays.asList(includes), Arrays.asList(excludes));
 			try {
-				final List<File> filesToAnalyze = FileUtils.getFiles(classDirectory, fileFilter.getIncludes(), fileFilter.getExcludes());
+				final List<File> filesToAnalyze = FileUtils.getFiles(classDirectory, String.join(",", includes), String.join(",", excludes));
 				for (final File file : filesToAnalyze) {
 					analyzer.analyzeAll(file);
 				}

--- a/src/test/java/hudson/plugins/jacoco/e2e/E2ETest.java
+++ b/src/test/java/hudson/plugins/jacoco/e2e/E2ETest.java
@@ -1,0 +1,108 @@
+package hudson.plugins.jacoco.e2e;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+import hudson.Functions;
+import hudson.model.Descriptor;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.jacoco.JacocoBuildAction;
+import hudson.plugins.jacoco.JacocoPublisher;
+import hudson.plugins.jacoco.model.Coverage;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Builder;
+import hudson.tasks.Publisher;
+import hudson.tasks.Shell;
+import hudson.util.DescribableList;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static hudson.plugins.jacoco.e2e.E2ETest.CoverageMatcher.withCoverage;
+
+public class E2ETest {
+
+    @Rule
+    public RealJenkinsRule rjr = new RealJenkinsRule();
+
+    @Test
+    public void simpleTest() throws Throwable {
+        rjr.then(r -> {
+            FreeStyleProject project = r.createFreeStyleProject();
+            project.getBuildersList().addAll(createJacocoProjectBuilders());
+            project.getPublishersList().add(new JacocoPublisher());
+            
+            FreeStyleBuild build = r.buildAndAssertSuccess(project);
+
+            assertThat("plugin collected data", build.getLog(), containsString("Collecting JaCoCo coverage data"));
+
+            JacocoBuildAction action = build.getAction(JacocoBuildAction.class);
+            assertThat("Build has the Jacoco Action", action, notNullValue());
+            
+            assertThat("incorrect branch coverage reported", action.getBranchCoverage(), withCoverage(0, 621, 621));
+            assertThat("incorrect class coverage reported", action.getClassCoverage(), withCoverage(7, 59, 66));
+            assertThat("incorrect complexity coverage reported", action.getComplexityScore(), withCoverage(19, 835, 854));
+            assertThat("incorrect instruction coverage reported", action.getInstructionCoverage(), withCoverage(229, 9013, 9242));
+            assertThat("incorrect line coverage reported", action.getLineCoverage(), withCoverage(53, 1860, 1913));
+        }
+        );
+    }
+
+    private static List<Builder> createJacocoProjectBuilders() {
+        String[] commands = { "git clone --branch jacoco-3.2.0 https://github.com/jenkinsci/jacoco-plugin.git .",
+                "mvn -P enable-jacoco -B -Dtest=ClassReportTest test" };
+        List<Builder> builders = new ArrayList<>();
+        if (Functions.isWindows()) {
+            for (String command : commands) {
+                builders.add(new BatchFile(command));
+            }
+        } else {
+            for (String command : commands) {
+                builders.add(new Shell(command));
+            }
+        }
+        return builders;
+    }
+    
+    public static class CoverageMatcher extends TypeSafeDiagnosingMatcher<Coverage> {
+
+        private final int covered;
+        private final int missed;
+        private final int total;
+
+        private CoverageMatcher(int covered, int missed, int total) {
+            this.covered = covered;
+            this.missed = missed;
+            this.total = total;
+        }
+        @Override
+        public void describeTo(Description description) {
+            description.appendText(" with covered="+ covered);
+            description.appendText(" and missed="+ missed);
+            description.appendText(" and total="+ total);
+            
+        }
+
+        @Override
+        protected boolean matchesSafely(Coverage coverage, Description mismatchDescription) {
+            mismatchDescription.appendText(" with covered="+ coverage.getCovered());
+            mismatchDescription.appendText(" and missed="+ coverage.getMissed());
+            mismatchDescription.appendText(" and total="+ coverage.getTotal());
+
+            return coverage.getCovered() == covered && 
+                    coverage.getMissed() == missed &&
+                    coverage.getTotal() == total;
+        }
+    
+        public static CoverageMatcher withCoverage(int covered, int missed, int total) {
+            return new CoverageMatcher(covered, missed, total);
+        }
+    }
+}

--- a/src/test/java/hudson/plugins/jacoco/e2e/E2ETest.java
+++ b/src/test/java/hudson/plugins/jacoco/e2e/E2ETest.java
@@ -49,7 +49,10 @@ public class E2ETest {
             assertThat("incorrect branch coverage reported", action.getBranchCoverage(), withCoverage(0, 621, 621));
             assertThat("incorrect class coverage reported", action.getClassCoverage(), withCoverage(7, 59, 66));
             assertThat("incorrect complexity coverage reported", action.getComplexityScore(), withCoverage(19, 835, 854));
-            assertThat("incorrect instruction coverage reported", action.getInstructionCoverage(), withCoverage(229, 9013, 9242));
+            // different compilers can generate different instructions (e.g. java8 vs java 11.
+            // so just skip this for now as it seems brittle
+            // assertThat("incorrect instruction coverage reported", action.getInstructionCoverage(), withCoverage(229, 9013, 9242)); /* java 8* /
+            // assertThat("incorrect instruction coverage reported", action.getInstructionCoverage(), withCoverage(229, 9010 , 9239)); /* java 11 */
             assertThat("incorrect line coverage reported", action.getLineCoverage(), withCoverage(53, 1860, 1913));
         }
         );
@@ -92,7 +95,7 @@ public class E2ETest {
 
         @Override
         protected boolean matchesSafely(Coverage coverage, Description mismatchDescription) {
-            mismatchDescription.appendText(" with covered="+ coverage.getCovered());
+            mismatchDescription.appendText("Coverage with covered="+ coverage.getCovered());
             mismatchDescription.appendText(" and missed="+ coverage.getMissed());
             mismatchDescription.appendText(" and total="+ coverage.getTotal());
 


### PR DESCRIPTION
[JENKINS-65757](https://issues.jenkins.io/browse/JENKINS-65757) The dependencies was a mess due to pulling libraries in that where comletely un-needed.

Even plexus could probably be removed with a bit more effort - but at least plexus is safe.

Maven etc was pulling in guva and a misguided attempt to bundle it along with the plugin first classloaded caused all hell to break loose as guice saw things loaded from separate classloaders and it was not happy

Added a proper realistic E2E test (there where not even any semi realistic ones) using `RealJenkinsRule` to ensure this still works with a FreeStyleProject creating jacoco coverage via maven (a tag of this project)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
