### PR TITLE
add asm dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@ THE SOFTWARE.
             <artifactId>structs</artifactId>
             <version>1.20</version>
         </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.1</version>
+        </dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When running PCT under Jenkins 2.303, plugin fails `E2ETest.simpleTest` with the error `Caused: java.lang.NoClassDefFoundError: org/objectweb/asm/ClassVisitor`
Looking at the dependency tree, the plugin uses `org.ow2.asm.asm:9.1`. Adding that to the dependency tree and the failure went away.

CC @jtnord 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
