### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,8 +273,6 @@ THE SOFTWARE.
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <argLine>@{argLine} ${argLine}</argLine>
-                    	<parallel>all</parallel>
-
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+
 <!--
 The MIT License
 
@@ -23,6 +25,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -142,21 +146,13 @@ THE SOFTWARE.
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.2.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.20</version>
-        </dependency>
+        
     </dependencies>
 
     <repositories>
@@ -277,6 +273,8 @@ THE SOFTWARE.
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <argLine>@{argLine} ${argLine}</argLine>
+                    	<parallel>all</parallel>
+
                     </configuration>
                 </plugin>
             </plugins>
@@ -346,3 +344,5 @@ THE SOFTWARE.
         </plugins>
     </build>
 </project>
+
+


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
jacoco
{groupId='org.hamcrest', artifactId='hamcrest-core'}
{groupId='org.jenkins-ci.plugins', artifactId='structs'}
{groupId='org.jenkins-ci.main', artifactId='jenkins-war'}
{groupId='com.github.spotbugs', artifactId='spotbugs-annotations'}
{groupId='net.jcip', artifactId='jcip-annotations'}
{groupId='org.codehaus.mojo', artifactId='animal-sniffer-annotations'}
{groupId='commons-logging', artifactId='commons-logging'}
{groupId='org.jenkins-ci', artifactId='test-annotations'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
