### PR TITLE
Prepare for sunset icon removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/jacoco/report/CoverageReport/index.jelly
+++ b/src/main/resources/hudson/plugins/jacoco/report/CoverageReport/index.jelly
@@ -5,7 +5,7 @@
     <l:main-panel>
       <h2>${%JaCoCo Coverage Report}</h2>
       <div>
-        <img src="${imagesURL}/24x24/save.png" />
+        <l:icon class="icon-save icon-md" />
 
         <a href="jacoco.exec">Download <tt>jacoco.exec</tt> binary coverage file</a>
       </div>


### PR DESCRIPTION
This is a preparation for `https://github.com/jenkinsci/jenkins/pull/5778` which removes sunset icons.

Otherwise we're lacking an icon here:
![](https://i.imgur.com/iWQ6xQ1.png)

Which has been mitigated:
![](https://i.imgur.com/5K07Tuq.png)

cc @centic9 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue