### PR TITLE
Remove obsolete FindBugs configuration

### DIFF
--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,8 +1,0 @@
-<FindBugsFilter>
-    <!-- This started to show up after the logger was in place for a long time
-        Not sure how else it can be fixed... -->
-    <Match>
-        <Class name="hudson.plugins.jacoco.JacocoBuildAction" />
-        <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED" />
-    </Match>
-</FindBugsFilter>


### PR DESCRIPTION
This FindBugs configuration file has long been unused since we moved to SpotBugs several years ago.