### PR TITLE
Use standard SCM URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@ THE SOFTWARE.
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/jenkinsci/jacoco-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/jacoco-plugin.git</developerConnection>
+        <connection>scm:git:https://github.com/jenkinsci/jacoco-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/jacoco-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/jacoco-plugin</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
This PR updates the SCM URLs to use the standard format used in other Jenkins plugins and the archetype. This format is less likely to cause problems for Plugin Compatibility Tester (PCT) and Maven Release Plugin (MRP).