### PR TITLE
Upgrade Mockito; remove PowerMock

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.6</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(jdkVersions: [8, 11])
+buildPlugin(useContainerAgent: true, configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])
 
 // More complex Jenkinsfile sample: https://github.com/jenkinsci/graphql-server-plugin/blob/master/Jenkinsfile

--- a/pom.xml
+++ b/pom.xml
@@ -33,23 +33,24 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.19</version>
+        <version>4.55</version>
+        <relativePath />
     </parent>
 
     <artifactId>jacoco</artifactId>
-    <version>3.3.3-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
 
     <name>Jenkins JaCoCo plugin</name>
-    <url>https://github.com/jenkinsci/jacoco-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
-        <java.level>8</java.level>
+        <revision>3.3.3</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jacoco.version>0.8.8</jacoco.version>
         <!-- see https://www.jenkins.io/changelog-stable/ for changelog of the LTS releases -->
-        <jenkins.version>2.277.1</jenkins.version>
-        <!--  until the plugin-pom picks up a newer version -->
-        <jenkins-test-harness.version>1589.vc23fca066d5c</jenkins-test-harness.version>
+        <jenkins.version>2.361.4</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- Do not fail if tests are run without argLine -->
         <argLine />
     </properties>
@@ -104,10 +105,10 @@ THE SOFTWARE.
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/jenkinsci/jacoco-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/jacoco-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/jacoco-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
 
     <distributionManagement>
@@ -117,11 +118,22 @@ THE SOFTWARE.
         </repository>
     </distributionManagement>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1836.vfe602c266c05</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>dashboard-view</artifactId>
-            <version>2.18.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -132,25 +144,19 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>4.3</version>
+            <version>5.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>${powermock.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.2.1</version>
+            <version>3.5.1</version>
         </dependency>
         
     </dependencies>
@@ -323,21 +329,6 @@ THE SOFTWARE.
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>hpi</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <maskClasses>org.objectweb.asm.</maskClasses>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/hudson/plugins/jacoco/model/Coverage.java
+++ b/src/main/java/hudson/plugins/jacoco/model/Coverage.java
@@ -6,7 +6,7 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 /**
- * Represents <tt>x/y</tt> where x={@link #missed} and y={@link #covered}.
+ * Represents {@code x/y} where x={@link #missed} and y={@link #covered}.
  * 
  * @author Kohsuke Kawaguchi
  * @author Jonathan Fuerth

--- a/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
+++ b/src/test/java/hudson/plugins/jacoco/JacocoPublisherTest.java
@@ -29,10 +29,6 @@ import org.jacoco.core.internal.analysis.ClassCoverageImpl;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -49,14 +45,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JacocoPublisher.class)
-// See e.g. https://issues.jenkins-ci.org/browse/JENKINS-55179
-@org.powermock.core.classloader.annotations.PowerMockIgnore({
-		"com.sun.org.apache.xerces.*",
-		"javax.xml.*",
-		"org.xml.*",
-		"javax.management.*"})
 public class JacocoPublisherTest extends AbstractJacocoTestBase {
     private final TaskListener taskListener = niceMock(TaskListener.class);
     private final Launcher launcher = niceMock(Launcher.class);
@@ -496,8 +484,8 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 	public void testPerformWithBuildOverBuild() throws IOException, InterruptedException {
 
 		// expect
-		final Run run = PowerMock.createNiceMock(Run.class);
-		final Job job = PowerMock.createNiceMock(Job.class);
+		final Run run = niceMock(Run.class);
+		final Job job = niceMock(Job.class);
 
 		expect(run.getResult()).andReturn(Result.SUCCESS).anyTimes();
 		expect(run.getEnvironment(taskListener)).andReturn(new EnvVars()).anyTimes();
@@ -522,7 +510,7 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 			expect(run.getParent()).andReturn(job).anyTimes();
 			expect(job.getLastSuccessfulBuild()).andReturn(run).anyTimes();
 
-			PowerMock.replay(taskListener, run, job);
+			replay(taskListener, run, job);
 
 			// execute
 			//noinspection deprecation
@@ -540,6 +528,6 @@ public class JacocoPublisherTest extends AbstractJacocoTestBase {
 		}
 
 		// verify
-		PowerMock.verify(taskListener, run, job);
+		verify(taskListener, run, job);
 	}
 }

--- a/src/test/java/hudson/plugins/jacoco/portlet/JacocoDeltaCoverageResultSummaryTest.java
+++ b/src/test/java/hudson/plugins/jacoco/portlet/JacocoDeltaCoverageResultSummaryTest.java
@@ -6,28 +6,18 @@ import hudson.plugins.jacoco.portlet.bean.JacocoCoverageResultSummary;
 import hudson.plugins.jacoco.portlet.bean.JacocoDeltaCoverageResultSummary;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
 
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(JacocoLoadData.class)
-// See e.g. https://issues.jenkins-ci.org/browse/JENKINS-55179
-@org.powermock.core.classloader.annotations.PowerMockIgnore({
-        "com.sun.org.apache.xerces.*",
-        "javax.xml.*",
-        "org.xml.*",
-        "javax.management.*"})
 public class JacocoDeltaCoverageResultSummaryTest {
 
-    private final Run run = PowerMock.createNiceMock(Run.class);
-    private final Job job = PowerMock.createNiceMock(Job.class);
+    private final Run run = mock(Run.class);
+    private final Job job = mock(Job.class);
 
     JacocoCoverageResultSummary lastSuccessfulBuildCoverage, currentBuildwithMoreCoverage, currentBuildWithLesserCoverage;
 
@@ -59,63 +49,59 @@ public class JacocoDeltaCoverageResultSummaryTest {
     @Test
     public void deltaCoverageSummaryForBetterBuildTest(){
 
-        expect(run.getParent()).andReturn(job).anyTimes();
-        expect(job.getLastSuccessfulBuild()).andReturn(run).anyTimes();
-        PowerMock.mockStatic(JacocoLoadData.class);
-        expect(JacocoLoadData.getResult(run)).andReturn(lastSuccessfulBuildCoverage);
-        expect(JacocoLoadData.getResult(run)).andReturn(currentBuildwithMoreCoverage);
+        when(run.getParent()).thenReturn(job);
+        when(job.getLastSuccessfulBuild()).thenReturn(run);
 
-        PowerMock.replay(run, job);
-        PowerMock.replay(JacocoLoadData.class);
+        try (MockedStatic<JacocoLoadData> staticJacocoLoadData = mockStatic(JacocoLoadData.class)) {
+            staticJacocoLoadData
+                    .when(() -> JacocoLoadData.getResult(any()))
+                    .thenReturn(lastSuccessfulBuildCoverage)
+                    .thenReturn(currentBuildwithMoreCoverage);
 
-        JacocoDeltaCoverageResultSummary deltaCoverageSummary = JacocoDeltaCoverageResultSummary.build(run);
+            JacocoDeltaCoverageResultSummary deltaCoverageSummary = JacocoDeltaCoverageResultSummary.build(run);
 
-        PowerMock.verify(run, job);
-        PowerMock.verify(JacocoLoadData.class);
-
-        assertEquals("Absolute difference in instruction coverage",
+            assertEquals("Absolute difference in instruction coverage",
                 currentBuildwithMoreCoverage.getInstructionCoverage() - lastSuccessfulBuildCoverage.getInstructionCoverage(), deltaCoverageSummary.getInstructionCoverage(), 0.00001);
-        assertEquals("Absolute difference in branch coverage",
+            assertEquals("Absolute difference in branch coverage",
                 currentBuildwithMoreCoverage.getBranchCoverage() - lastSuccessfulBuildCoverage.getBranchCoverage(), deltaCoverageSummary.getBranchCoverage(), 0.00001);
-        assertEquals("Absolute difference in complexity coverage",
+            assertEquals("Absolute difference in complexity coverage",
                 currentBuildwithMoreCoverage.getComplexityScore() - lastSuccessfulBuildCoverage.getComplexityScore(), deltaCoverageSummary.getComplexityCoverage(), 0.00001);
-        assertEquals("Absolute difference in line coverage",
+            assertEquals("Absolute difference in line coverage",
                 currentBuildwithMoreCoverage.getLineCoverage() - lastSuccessfulBuildCoverage.getLineCoverage(), deltaCoverageSummary.getLineCoverage(), 0.00001);
-        assertEquals("Absolute difference in method coverage",
+            assertEquals("Absolute difference in method coverage",
                 currentBuildwithMoreCoverage.getMethodCoverage() - lastSuccessfulBuildCoverage.getMethodCoverage(), deltaCoverageSummary.getMethodCoverage(), 0.00001);
-        assertEquals("Absolute difference in class coverage",
+            assertEquals("Absolute difference in class coverage",
                 currentBuildwithMoreCoverage.getClassCoverage() - lastSuccessfulBuildCoverage.getClassCoverage(), deltaCoverageSummary.getClassCoverage(), 0.00001);
+        }
     }
 
     // Test delta coverage summary when current build has worse coverage than previous successful build
     @Test
     public void deltaCoverageSummaryForWorseBuildTest(){
 
-        expect(run.getParent()).andReturn(job).anyTimes();
-        expect(job.getLastSuccessfulBuild()).andReturn(run).anyTimes();
-        PowerMock.mockStatic(JacocoLoadData.class);
-        expect(JacocoLoadData.getResult(run)).andReturn(lastSuccessfulBuildCoverage);
-        expect(JacocoLoadData.getResult(run)).andReturn(currentBuildWithLesserCoverage);
+        when(run.getParent()).thenReturn(job);
+        when(job.getLastSuccessfulBuild()).thenReturn(run);
 
-        PowerMock.replay(run, job);
-        PowerMock.replay(JacocoLoadData.class);
+        try (MockedStatic<JacocoLoadData> staticJacocoLoadData = mockStatic(JacocoLoadData.class)) {
+            staticJacocoLoadData
+                    .when(() -> JacocoLoadData.getResult(any()))
+                    .thenReturn(lastSuccessfulBuildCoverage)
+                    .thenReturn(currentBuildWithLesserCoverage);
 
-        JacocoDeltaCoverageResultSummary deltaCoverageSummary = JacocoDeltaCoverageResultSummary.build(run);
+            JacocoDeltaCoverageResultSummary deltaCoverageSummary = JacocoDeltaCoverageResultSummary.build(run);
 
-        PowerMock.verify(run, job);
-        PowerMock.verify(JacocoLoadData.class);
-
-        assertEquals("Absolute difference in instruction coverage",
+            assertEquals("Absolute difference in instruction coverage",
                 currentBuildWithLesserCoverage.getInstructionCoverage() - lastSuccessfulBuildCoverage.getInstructionCoverage(), deltaCoverageSummary.getInstructionCoverage(), 0.00001);
-        assertEquals("Absolute difference in branch coverage",
+            assertEquals("Absolute difference in branch coverage",
                 currentBuildWithLesserCoverage.getBranchCoverage() - lastSuccessfulBuildCoverage.getBranchCoverage(), deltaCoverageSummary.getBranchCoverage(), 0.00001);
-        assertEquals("Absolute difference in complexity coverage",
+            assertEquals("Absolute difference in complexity coverage",
                 currentBuildWithLesserCoverage.getComplexityScore() - lastSuccessfulBuildCoverage.getComplexityScore(), deltaCoverageSummary.getComplexityCoverage(), 0.00001);
-        assertEquals("Absolute difference in line coverage",
+            assertEquals("Absolute difference in line coverage",
                 currentBuildWithLesserCoverage.getLineCoverage() - lastSuccessfulBuildCoverage.getLineCoverage(), deltaCoverageSummary.getLineCoverage(), 0.00001);
-        assertEquals("Absolute difference in method coverage",
+            assertEquals("Absolute difference in method coverage",
                 currentBuildWithLesserCoverage.getMethodCoverage() - lastSuccessfulBuildCoverage.getMethodCoverage(), deltaCoverageSummary.getMethodCoverage(), 0.00001);
-        assertEquals("Absolute difference in class coverage",
+            assertEquals("Absolute difference in class coverage",
                 currentBuildWithLesserCoverage.getClassCoverage() - lastSuccessfulBuildCoverage.getClassCoverage(), deltaCoverageSummary.getClassCoverage(), 0.00001);
+        }
     }
 }

--- a/src/test/java/hudson/plugins/jacoco/portlet/JacocoLoadDataHudsonTest.java
+++ b/src/test/java/hudson/plugins/jacoco/portlet/JacocoLoadDataHudsonTest.java
@@ -18,12 +18,6 @@ import java.io.InputStream;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  * @author Mauro Durante Junior (Mauro.Durantejunior@sonyericsson.com)
  */
-// See e.g. https://issues.jenkins-ci.org/browse/JENKINS-55179
-@org.powermock.core.classloader.annotations.PowerMockIgnore({
-        "com.sun.org.apache.xerces.*",
-        "javax.xml.*",
-        "org.xml.*",
-        "javax.management.*"})
 public class JacocoLoadDataHudsonTest extends HudsonTestCase {
 
     /**


### PR DESCRIPTION
PowerMock has been removed from the plugin parent POM and does not work with Java 17, and it does not work with recent versions of Mockito. This PR replaces usage of PowerMock with the latest version of mockito-inline, which supports Java 17. Reviewers are encouraged to review this PR with the **Hide Whitespace** feature enabled. CC @centic9