### PR TITLE
[SECURITY-3061]

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/report/AbstractReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/AbstractReport.java
@@ -31,7 +31,18 @@ public abstract class AbstractReport<PARENT extends AggregatedReport<?,PARENT,?>
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = sanitizeName(name);
+    }
+
+    protected static String sanitizeName(String name) {
+        // sanitize names contained in .class files
+        return name
+                .replace(':', '_')
+                .replace(';', '_')
+                .replace('&', '_')
+                .replace('%', '_')
+                .replace('<', '_')
+                .replace('>', '_');
     }
 
     public String getDisplayName() {
@@ -72,5 +83,5 @@ public abstract class AbstractReport<PARENT extends AggregatedReport<?,PARENT,?>
     public Run<?,?> getBuild() {
     	return parent.getBuild();
     }
-    
+
 }

--- a/src/main/java/hudson/plugins/jacoco/report/ClassReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/ClassReport.java
@@ -15,9 +15,10 @@ public final class ClassReport extends AggregatedReport<PackageReport,ClassRepor
 
     @Override
 	public void setName(String name) {
-		super.setName(name.replaceAll("/", "."));
+		super.setName(name.replace('/', '.'));
 		//logger.log(Level.INFO, "ClassReport");
 	}
+
 	@Override
 	public void add(MethodReport child) {
     	String newChildName = child.getName();

--- a/src/main/java/hudson/plugins/jacoco/report/MethodReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/MethodReport.java
@@ -13,9 +13,9 @@ import org.jacoco.core.analysis.IMethodCoverage;
  */
 //AggregatedReport<PackageReport,ClassReport,MethodReport>  -  AbstractReport<ClassReport,MethodReport>
 public final class MethodReport extends AggregatedReport<ClassReport,MethodReport, SourceFileReport> {
-	
+
 	private IMethodCoverage methodCov;
-	
+
 	@Override
 	public String printFourCoverageColumns() {
         StringBuilder buf = new StringBuilder();
@@ -32,10 +32,10 @@ public final class MethodReport extends AggregatedReport<ClassReport,MethodRepor
         //logger.log(Level.INFO, "Printing Ratio cells within MethodReport.");
 		return buf.toString();
 	}
-	
+
 	@Override
 	public void add(SourceFileReport child) {
-    	String newChildName = child.getName().replaceAll(this.getName() + ".", ""); 
+    	String newChildName = child.getName().replace(this.getName() + ".", "");
     	child.setName(newChildName);
         getChildren().put(child.getName(), child);
         //logger.log(Level.INFO, "SourceFileReport");
@@ -45,11 +45,11 @@ public final class MethodReport extends AggregatedReport<ClassReport,MethodRepor
     public boolean hasClassCoverage() {
         return false;
     }
-	
+
 	public void setSrcFileInfo(IMethodCoverage methodCov) {
 		this.methodCov = methodCov;
 	}
-	
+
     public void printHighlightedSrcFile(Writer output) {
         new SourceAnnotator(getParent().getSourceFilePath()).printHighlightedSrcFile(methodCov,output);
    	}

--- a/src/main/java/hudson/plugins/jacoco/report/PackageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/PackageReport.java
@@ -18,17 +18,17 @@ public final class PackageReport extends AggregatedReport<CoverageReport,Package
 
     @Override
     public void setName(String name) {
-        super.setName(name.replaceAll("/", "."));
+        super.setName(name.replace('/', '.'));
     }
-    
+
     @Override
     public void add(ClassReport child) {
-    	String newChildName = child.getName().replaceAll(this.getName() + ".", ""); 
+    	String newChildName = child.getName().replace(this.getName() + ".", "");
     	child.setName(newChildName);
         this.getChildren().put(child.getName(), child);
         //logger.log(Level.INFO, "PackageReport");
     }
-    
+
     //private static final Logger logger = Logger.getLogger(CoverageObject.class.getName());
-    
+
 }

--- a/src/main/java/hudson/plugins/jacoco/report/SourceFileReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/SourceFileReport.java
@@ -5,12 +5,12 @@ package hudson.plugins.jacoco.report;
  * @author Kohsuke Kawaguchi
  */
 public final class SourceFileReport extends AbstractReport<MethodReport,SourceFileReport> {
-	
+
 	@Override
     public void setName(String name) {
-        super.setName(name.replaceAll("/", "."));
+        super.setName(name.replace('/', '.'));
     	//logger.log(Level.INFO, "SourceFileReport");
     }
-    	
+
 	//private static final Logger logger = Logger.getLogger(SourceFileReport.class.getName());
-}	
+}

--- a/src/test/java/hudson/plugins/jacoco/report/AbstractReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/AbstractReportTest.java
@@ -17,7 +17,7 @@ public class AbstractReportTest {
             // abstract class but not abstract method to override
         };
         assertNotNull(report);
-        
+
         report.setParent(new ClassReport());
         report.getParent().setParent(new PackageReport());
 
@@ -33,7 +33,11 @@ public class AbstractReportTest {
         report.setName("testname");
         assertEquals("testname", report.getName());
         assertEquals("testname", report.getDisplayName());
-        
+
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname/____2__", report.getName());
+        assertEquals("myname/____2__", report.getDisplayName());
+
         // TODO: cause NPEs, did not find out how to test this without a full jenkins-test
         //assertNull(report.getPreviousResult());
         //CoverageElement cv = new CoverageElement();

--- a/src/test/java/hudson/plugins/jacoco/report/AggregatedReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/AggregatedReportTest.java
@@ -11,10 +11,10 @@ public class AggregatedReportTest {
     public void testSetFailed() throws Exception {
         AggregatedReport<PackageReport,ClassReport,MethodReport> report = new AggregatedReport<PackageReport,ClassReport,MethodReport>() {
         };
-        
+
         assertEquals(0, report.getChildren().size());
         assertFalse(report.hasChildren());
-        
+
         MethodReport child = new MethodReport();
         child.setName("testmethod");
         report.add(child);
@@ -22,25 +22,29 @@ public class AggregatedReportTest {
         assertTrue(report.hasChildren());
         assertFalse(report.hasChildrenClassCoverage());
         assertFalse(report.hasChildrenLineCoverage());
-        
+
         report.setParent(new PackageReport());
         assertNotNull(report.getParent());
-        
+
         assertNull(report.getDynamic("test", null, null));
         assertNotNull(report.getDynamic("testmethod", null, null));
-        
+
         report.setFailed();
-        
+
         child.getLineCoverage().accumulate(0, 3);
         assertTrue(report.hasChildrenLineCoverage());
 
         child.getClassCoverage().accumulate(0, 3);
         assertFalse("For method children it's always false", report.hasChildrenClassCoverage());
+
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname/____2__", report.getName());
+        assertEquals("myname/____2__", report.getDisplayName());
     }
-    
+
     @Test
     public void testClassCoverage() {
-        AggregatedReport<CoverageReport,PackageReport,ClassReport> packageReport = 
+        AggregatedReport<CoverageReport,PackageReport,ClassReport> packageReport =
                 new AggregatedReport<CoverageReport, PackageReport, ClassReport>() {
                 };
 
@@ -52,8 +56,13 @@ public class AggregatedReportTest {
         assertFalse(packageReport.hasChildrenLineCoverage());
 
         classChild.getClassCoverage().accumulate(0, 3);
-        
+
         assertTrue(packageReport.hasChildrenClassCoverage());
         assertFalse(packageReport.hasChildrenLineCoverage());
+
+        classChild = new ClassReport();
+        classChild.setName("testclass/pkg");
+        packageReport.add(classChild);
+        assertEquals("testclass.pkg", classChild.getName());
     }
 }

--- a/src/test/java/hudson/plugins/jacoco/report/ClassReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/ClassReportTest.java
@@ -11,46 +11,50 @@ import org.junit.Test;
 public class ClassReportTest {
 
     @Test
-    public void testName() throws Exception {
+    public void testName() {
         ClassReport report = new ClassReport();
         report.setName("testname");
         assertEquals("testname", report.getName());
         report.setName("test/name/1");
         assertEquals("test.name.1", report.getName());
+
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname.____2__", report.getName());
+        assertEquals("myname.____2__", report.getDisplayName());
     }
-    
+
     @Test
-    public void testChildren() throws Exception {
+    public void testChildren() {
         ClassReport report = new ClassReport();
-        
+
         assertEquals(0, report.getChildren().size());
         MethodReport child = new MethodReport();
         child.setName("testname");
         report.add(child);
         assertEquals(1, report.getChildren().size());
     }
-    
+
     @Test
-    public void testSourceFile() throws Exception {
+    public void testSourceFile() {
         ClassReport report = new ClassReport();
         report.setSrcFileInfo(null, "some/path");
         assertEquals(new File("some/path"), report.getSourceFilePath());
     }
-    
+
     @Test
-    public void testPrint() throws Exception {
+    public void testPrint() {
         ClassReport report = new ClassReport();
         report.setSrcFileInfo(null, "some/path");
-        
+
         StringWriter writer = new StringWriter();
         report.printHighlightedSrcFile(writer);
-        
+
         String string = writer.toString();
         assertEquals("ERROR: Error while reading the sourcefile!", string);
     }
-    
+
     @Test
-    public void testToString() throws Exception {
+    public void testToString() {
         ClassReport report = new ClassReport();
         assertNotNull(report.toString());
     }

--- a/src/test/java/hudson/plugins/jacoco/report/CoverageReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/CoverageReportTest.java
@@ -11,19 +11,23 @@ import org.junit.Test;
 
 public class CoverageReportTest {
     @Test
-    public void testGetBuild() throws Exception {
+    public void testGetBuild() {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
         assertNull(report.getBuild());
     }
 
     @Test
-    public void testName() throws Exception {
+    public void testName() {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
         assertEquals("Jacoco", report.getName());
+
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname/____2__", report.getName());
+        assertEquals("myname/____2__", report.getDisplayName());
     }
 
     @Test
-    public void testDoJaCoCoExec() throws Exception {
+    public void testDoJaCoCoExec() {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
         assertNotNull(report);
         // TODO: how to simulate JaCoCoBuildAction without full Jenkins test-framework?
@@ -31,7 +35,7 @@ public class CoverageReportTest {
     }
 
     @Test
-    public void testThresholds() throws Exception {
+    public void testThresholds() {
         CoverageReport report = new CoverageReport(action, new ExecutionFileLoader());
         report.setThresholds(new JacocoHealthReportThresholds());
     }

--- a/src/test/java/hudson/plugins/jacoco/report/MethodReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/MethodReportTest.java
@@ -12,47 +12,53 @@ public class MethodReportTest {
     public void testMissingFile() {
         MethodReport report = new MethodReport();
         assertFalse(report.hasClassCoverage());
-        
+
         report.setSrcFileInfo(null);
-        
+
         ClassReport p = new ClassReport();
         p.setSrcFileInfo(null, "some/path");
         report.setParent(p);
-        
+
         StringWriter writer = new StringWriter();
         report.printHighlightedSrcFile(writer);
         String string = writer.toString();
         assertEquals("ERROR: Error while reading the sourcefile!", string);
+
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname/____2__", report.getName());
+        assertEquals("myname/____2__", report.getDisplayName());
     }
 
     @Test
-    public void testPrint() throws Exception {
+    public void testPrint() {
         MethodReport report = new MethodReport();
         assertNotNull(report.printFourCoverageColumns());
     }
 
     @Test
-    public void testChildren() throws Exception {
+    public void testChildren() {
         MethodReport report = new MethodReport();
         report.setName("pkg");
-        
+
         assertEquals(0, report.getChildren().size());
         SourceFileReport child = new SourceFileReport();
         child.setName("testname");
         report.add(child);
+        assertEquals("testname", child.getName());
         assertEquals(1, report.getChildren().size());
         assertEquals("testname", report.getChildren().values().iterator().next().getName());
     }
 
     @Test
-    public void testChildrenRemovePkgName() throws Exception {
+    public void testChildrenRemovePkgName() {
         MethodReport report = new MethodReport();
         report.setName("pkg");
-        
+
         assertEquals(0, report.getChildren().size());
         SourceFileReport child = new SourceFileReport();
         child.setName("pkg.testname");
         report.add(child);
+        assertEquals("testname", child.getName());
         assertEquals(1, report.getChildren().size());
         assertEquals("testname", report.getChildren().values().iterator().next().getName());
     }

--- a/src/test/java/hudson/plugins/jacoco/report/PackageReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/PackageReportTest.java
@@ -8,9 +8,9 @@ import org.junit.Test;
 public class PackageReportTest {
 
     @Test
-    public void testName() throws Exception {
+    public void testName() {
         PackageReport report = new PackageReport();
-        
+
         report.setName("");
         assertEquals("(default)", report.getName());
 
@@ -19,30 +19,36 @@ public class PackageReportTest {
 
         report.setName("test/name/1");
         assertEquals("test.name.1", report.getName());
+
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname.____2__", report.getName());
+        assertEquals("myname.____2__", report.getDisplayName());
     }
 
     @Test
-    public void testChildren() throws Exception {
+    public void testChildren() {
         PackageReport report = new PackageReport();
         report.setName("pkg");
-        
+
         assertEquals(0, report.getChildren().size());
         ClassReport child = new ClassReport();
         child.setName("testname");
         report.add(child);
+        assertEquals("testname", child.getName());
         assertEquals(1, report.getChildren().size());
         assertEquals("testname", report.getChildren().values().iterator().next().getName());
     }
 
     @Test
-    public void testChildrenRemovePkgName() throws Exception {
+    public void testChildrenRemovePkgName() {
         PackageReport report = new PackageReport();
         report.setName("pkg");
-        
+
         assertEquals(0, report.getChildren().size());
         ClassReport child = new ClassReport();
         child.setName("pkg.testname");
         report.add(child);
+        assertEquals("testname", child.getName());
         assertEquals(1, report.getChildren().size());
         assertEquals("testname", report.getChildren().values().iterator().next().getName());
     }

--- a/src/test/java/hudson/plugins/jacoco/report/SourceFileReportTest.java
+++ b/src/test/java/hudson/plugins/jacoco/report/SourceFileReportTest.java
@@ -12,5 +12,10 @@ public class SourceFileReportTest {
         SourceFileReport report = new SourceFileReport();
         report.setName("myname");
         assertEquals("myname", report.getName());
+        report.setName("myname/2");
+        assertEquals("myname.2", report.getName());
+        report.setName("myname/&:<>2%;");
+        assertEquals("myname.____2__", report.getName());
+        assertEquals("myname.____2__", report.getDisplayName());
     }
 }


### PR DESCRIPTION
Integrate fix for SECURITY-3061 into `master` branch.

Since the private repo had this commit on its `master` branch, I assume the idea is for this to be merged into public `master`. https://github.com/jenkinsci/jacoco-plugin/commit/6cd38c06e3f4c0ef1b5662e84fc9423616d595bf caused the branches to diverge.

Alternatively there's also https://github.com/jenkinsci/jacoco-plugin/tree/3.3.2.x, from which 3.3.2.1 was released, which you can integrate at https://github.com/jenkinsci/jacoco-plugin/compare/3.3.2.x?expand=1. In that case I recommend merging using merge-commit, to retain the release commits on the history of the default branch.

**IMPORTANT:** I've made the master branch read-only to prevent accidental releases from merging other PRs that do not contain this security fix. Delete the branch protection rule to revert this.