### PR TITLE
EOL JSR 305

### DIFF
--- a/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoBuildAction.java
@@ -11,7 +11,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jvnet.localizer.Localizable;

--- a/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoPublisher.java
@@ -33,7 +33,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.plugins.jacoco.portlet.bean.JacocoDeltaCoverageResultSummary;
 
 /**
@@ -821,7 +821,7 @@ public class JacocoPublisher extends Recorder implements SimpleBuildStep {
             setDescriptor(this);
         }
 
-		@Nonnull
+		@NonNull
         @Override
         public String getDisplayName() {
             return Messages.JacocoPublisher_DisplayName();

--- a/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
+++ b/src/main/java/hudson/plugins/jacoco/JacocoReportDir.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Encapsulates the directory structure in $JENKINS_HOME where we store jacoco related files.
@@ -28,7 +28,7 @@ public class JacocoReportDir {
         return new File(root,"classes");
     }
 
-    public int saveClassesFrom(@Nonnull FilePath dir, @Nonnull String fileMask) throws IOException, InterruptedException {
+    public int saveClassesFrom(@NonNull FilePath dir, @NonNull String fileMask) throws IOException, InterruptedException {
         FilePath d = new FilePath(getClassesDir());
         d.mkdirs();
         return dir.copyRecursiveTo(fileMask, d);
@@ -42,7 +42,7 @@ public class JacocoReportDir {
         return new File(root,"sources");
     }
 
-    public int saveSourcesFrom(@Nonnull FilePath dir, @Nonnull String inclusionMask, @Nonnull String exclusionMask) throws IOException, InterruptedException {
+    public int saveSourcesFrom(@NonNull FilePath dir, @NonNull String inclusionMask, @NonNull String exclusionMask) throws IOException, InterruptedException {
         FilePath d = new FilePath(getSourcesDir());
         d.mkdirs();
         return dir.copyRecursiveTo(inclusionMask, exclusionMask, d);

--- a/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
+++ b/src/main/java/hudson/plugins/jacoco/report/CoverageReport.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 
 import hudson.model.Run;
@@ -59,7 +59,7 @@ public final class CoverageReport extends AggregatedReport<CoverageReport/*dummy
 	 * @param action Jacoco build action
 	 * @param executionFileLoader execution file loader owning bundle coverage
 	 */
-	public CoverageReport(JacocoBuildAction action, @Nonnull ExecutionFileLoader executionFileLoader ) {
+	public CoverageReport(JacocoBuildAction action, @NonNull ExecutionFileLoader executionFileLoader ) {
 		this(action);
 		action.getLogger().println("[JaCoCo plugin] Loading packages..");
 

--- a/src/main/java/hudson/plugins/jacococoveragecolumn/BranchCoverageColumn.java
+++ b/src/main/java/hudson/plugins/jacococoveragecolumn/BranchCoverageColumn.java
@@ -9,7 +9,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * View column that shows the code branch coverage percentage
@@ -38,7 +38,7 @@ public class BranchCoverageColumn extends AbstractJaCoCoCoverageColumn {
 	private static class DescriptorImpl extends ListViewColumnDescriptor {
 		@Override
 		public ListViewColumn newInstance(final StaplerRequest req,
-										  @Nonnull final JSONObject formData) {
+										  @NonNull final JSONObject formData) {
 			return new BranchCoverageColumn();
 		}
 		
@@ -47,7 +47,7 @@ public class BranchCoverageColumn extends AbstractJaCoCoCoverageColumn {
 			return false;
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "JaCoCo Branch Coverage";

--- a/src/main/java/hudson/plugins/jacococoveragecolumn/JaCoCoColumn.java
+++ b/src/main/java/hudson/plugins/jacococoveragecolumn/JaCoCoColumn.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * View column that shows the code line coverage percentage
@@ -40,7 +40,7 @@ public class JaCoCoColumn extends AbstractJaCoCoCoverageColumn {
 	private static class DescriptorImpl extends ListViewColumnDescriptor {
 		@Override
 		public ListViewColumn newInstance(final StaplerRequest req,
-										  @Nonnull final JSONObject formData) {
+										  @NonNull final JSONObject formData) {
 			return new JaCoCoColumn();
 		}
 
@@ -49,7 +49,7 @@ public class JaCoCoColumn extends AbstractJaCoCoCoverageColumn {
 			return false;
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "JaCoCo Line Coverage";


### PR DESCRIPTION
Several years ago, Jenkins core switched from the abandoned JSR 305 annotations to SpotBugs annotations, but this plugin never caught up. This PR adapts this plugin to the common convention used in Jenkins core and the vast majority of other Jenkins plugins.