### PR TITLE
Remove reference to old `com.cloudbees:maven-license-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,19 +266,6 @@ THE SOFTWARE.
                                         <ignore />
                                     </action>
                                 </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>com.cloudbees</groupId>
-                                        <artifactId>maven-license-plugin</artifactId>
-                                        <versionRange>[1.4,)</versionRange>
-                                        <goals>
-                                            <goal>process</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
a91b19bc400da4ddad4fc66a633ba90fbeee669b did not explain why this was necessary for Eclipse M2E users or under which conditions it could be removed. Other plugins do not have such configuration, so maybe it is obsolete has as well. The plugin is being renamed (https://github.com/jenkinsci/license-maven-plugin/issues/20) so if and when an Eclipse user needs special configuration they can retest.