### PR TITLE
Fix bad release tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ THE SOFTWARE.
         <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
-        <tag>jacoco-3.3.4</tag>
+        <tag>${scmTag}</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Something went wrong during the release of 3.3.4 in https://github.com/jenkinsci/jacoco-plugin/commit/c619efc2dbab72bba806a2be8dd1f0eb19c7c2fe, forgetting to return to the `<tag>` template, causing issues with the Jenkins incrementals publisher:

> 2023-07-06T18:05:29.975Z error:     Invalid archive Error: ZIP error: Error: Wrong commit hash in /project/scm/tag, expected 6e2e029575ca105d777943349f701cdba3139409, got jacoco-3.3.4                                                                                        

The change proposed resolves the issue by putting the appropriate `<tag>` placeholder back.