### PR TITLE
Fix dependabot scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
There are no GitHub actions to update, therefore dependabot fails to run this task:

![Screenshot 2023-08-30 at 08 35 03](https://github.com/jenkinsci/jacoco-plugin/assets/13383509/732a8b4e-d9cc-420f-9e97-89123302f895)