### PR TITLE
Suppress spotbugs PA_PUBLIC_PRIMITIVE_ATTRIBUTE warnings

### DIFF
--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be
+    false positives.
+  -->
+  <Match>
+    <!-- These primitive attributes need to be public to preserve the API -->
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
+    <Class name="hudson.plugins.jacoco.JacocoPublisher" />
+    <Or>
+      <Field name="DESCRIPTOR" />
+      <Field name="deltaHealthReport" />
+      <Field name="healthReports" />
+    </Or>
+  </Match>
+  <Match>
+    <!-- These primitive attributes need to be public to preserve the API -->
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
+    <Class name="hudson.plugins.jacoco.model.CoverageObject" />
+    <Or>
+      <Field name="maxBranch" />
+      <Field name="maxClazz" />
+      <Field name="maxComplexity" />
+      <Field name="maxInstruction" />
+      <Field name="maxLine" />
+      <Field name="maxMethod" />
+    </Or>
+  </Match>
+  <Match>
+    <!-- This primitive attribute needs to be public to preserve the API -->
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
+    <Class name="hudson.plugins.jacoco.report.CoverageReport" />
+    <Field name="healthReports" />
+  </Match>
+
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet
+    been triaged. When working on this section, pick an exclusion to
+    triage, then:
+
+    - Add a @SuppressFBWarnings(value = "[...]", justification = "[...]")
+      annotation if it is a false positive.  Indicate the reason why
+      it is a false positive, then remove the exclusion from this
+      section.
+
+    - If it is not a false positive, fix the bug, then remove the
+      exclusion from this section.
+   -->
+</FindBugsFilter>


### PR DESCRIPTION
## Suppress spotbugs PA_PUBLIC_PRIMITIVE_ATTRIBUTE warnings

The [improve a plugin tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/add-more-spotbugs-checks/) describes the technique used here with an exclusions file.  The specific exclusion for PA_PUBLIC_PRIMITIVE_ATTRIBUTE has been confirmed by Jenkins developers that it is not helpful in a Jenkins plugin.

[Jenkins core PR-8803](https://github.com/jenkinsci/jenkins/pull/8803) describes the changes that were made in Jenkins core and in many Jenkins plugins to suppress the PA_PUBLIC_PRIMITIVE_ATTRIBUTE spotbugs warning.

### Testing done

Confirmed that spotbugs warnings are visible before this change and are resolved after this change.  No change to Java source code or the pom file.  Uses the default location of the spotbugs suppression file from the parent pom.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
