### PR TITLE
Override `assignBuildNumber` rather than `saveNextBuildNumber`

### DIFF
--- a/src/test/java/hudson/plugins/jacococoveragecolumn/AbstractJaCoCoCoverageColumnTest.java
+++ b/src/test/java/hudson/plugins/jacococoveragecolumn/AbstractJaCoCoCoverageColumnTest.java
@@ -89,9 +89,10 @@ public class AbstractJaCoCoCoverageColumnTest {
 				}
 			}
 
-			@Override
-			protected synchronized void saveNextBuildNumber() {
-			}
+            @Override
+            public int assignBuildNumber() throws IOException {
+                return nextBuildNumber++;
+            }
 		};
 		assertTrue(abstractJaCoCoCoverageColumn.hasCoverage(mockJob));
 		assertEquals("66.67", abstractJaCoCoCoverageColumn.getPercent(mockJob));
@@ -218,8 +219,9 @@ public class AbstractJaCoCoCoverageColumnTest {
         }
 
         @Override
-		protected synchronized void saveNextBuildNumber() {
-		}
+        public int assignBuildNumber() throws IOException {
+            return nextBuildNumber++;
+        }
 	}
 	
 	private class MyJob extends Job<MyJob,MyRun> {

--- a/src/test/java/hudson/plugins/jacococoveragecolumn/BranchCoverageColumnTest.java
+++ b/src/test/java/hudson/plugins/jacococoveragecolumn/BranchCoverageColumnTest.java
@@ -57,9 +57,10 @@ public class BranchCoverageColumnTest {
 				}
 			}
 
-			@Override
-			protected synchronized void saveNextBuildNumber() {
-			}
+            @Override
+            public int assignBuildNumber() throws IOException {
+                return nextBuildNumber++;
+            }
 		};
 		assertEquals("66.67", sut.getPercent(mockJob));
 

--- a/src/test/java/hudson/plugins/jacococoveragecolumn/JaCoCoColumnTest.java
+++ b/src/test/java/hudson/plugins/jacococoveragecolumn/JaCoCoColumnTest.java
@@ -56,9 +56,10 @@ public class JaCoCoColumnTest {
 				}
 			}
 
-			@Override
-			protected synchronized void saveNextBuildNumber() {
-			}
+            @Override
+            public int assignBuildNumber() throws IOException {
+                return nextBuildNumber++;
+            }
 		};
 		assertTrue(jaCoCoColumn.hasCoverage(mockJob));
 		assertEquals("33.33", jaCoCoColumn.getPercent(mockJob));


### PR DESCRIPTION
Avoids test failures due to (ab)use of EasyMock when running against https://github.com/jenkinsci/jenkins/pull/9846.

I would appreciate a release after merge, to prevent problems in PCT.